### PR TITLE
Add option to strip box drawing characters ("│ │", for example in droid cli) when trimming

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "323cff72e770cf82f894d0e06257f0f8b477edd53e0e1c8fdf1edb8e185b5135",
+  "pins" : [
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "5581748cef2bae787496fe6d61139aebe0a451f6",
+        "version" : "2.8.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Tests/TrimmyTests/TrimmyTests.swift
+++ b/Tests/TrimmyTests/TrimmyTests.swift
@@ -82,4 +82,30 @@ struct TrimmyTests {
         let text = "Shopping list:\napples\noranges"
         #expect(detector.transformIfCommand(text) == nil)
     }
+
+    @Test
+    func removesBoxDrawingCharacters() {
+        let settings = AppSettings()
+        settings.removeBoxDrawing = true
+        let detector = CommandDetector(settings: settings)
+        let text = "hello │ │ world │ │ test"
+        #expect(detector.cleanBoxDrawingCharacters(text) == "hello  world  test")
+    }
+
+    @Test
+    func returnsNilWhenNoBoxDrawingCharacters() {
+        let settings = AppSettings()
+        let detector = CommandDetector(settings: settings)
+        let text = "hello world test"
+        #expect(detector.cleanBoxDrawingCharacters(text) == nil)
+    }
+
+    @Test
+    func respectsRemoveBoxDrawingSetting() {
+        let settings = AppSettings()
+        settings.removeBoxDrawing = false
+        let detector = CommandDetector(settings: settings)
+        let text = "hello │ │ world"
+        #expect(detector.cleanBoxDrawingCharacters(text) == nil)
+    }
 }


### PR DESCRIPTION

## Add option to remove box drawing characters before trimmingSummary: 
- add a `removeBoxDrawing` preference (default on) and expose it via the settings pane and menubar toggle
- run `cleanBoxDrawingCharacters` before the command detector so forced trims still write outtext when only │ │ sequences change, and make sure summaries reflect the cleaned text
- lock dependencies via Package.resolved and cover the new helper with regression tests