### PR TITLE
TrimmyCLI: use FileHandle stderr to fix Swift 6 concurrency warnings

### DIFF
--- a/Sources/TrimmyCLI/main.swift
+++ b/Sources/TrimmyCLI/main.swift
@@ -61,7 +61,7 @@ struct TrimmyCLI {
         }
 
         guard let input = readInput(path: inputPath) else {
-            fputs("No input provided. Use --trim <file> or pipe to stdin.\n", stderr)
+            FileHandle.standardError.write(Data("No input provided. Use --trim <file> or pipe to stdin.\n".utf8))
             exit(1)
         }
 
@@ -78,7 +78,7 @@ struct TrimmyCLI {
                 FileHandle.standardOutput.write(data)
                 FileHandle.standardOutput.write(Data([0x0A]))
             } catch {
-                fputs("Failed to encode JSON: \(error)\n", stderr)
+                FileHandle.standardError.write(Data("Failed to encode JSON: \(error)\n".utf8))
                 exit(3)
             }
         } else {


### PR DESCRIPTION
Switch TrimmyCLI stderr output to FileHandle.standardError so Swift 6/Linux concurrency checks stay happy when writing error messages. This avoids the shared-mutable-state warning around C FILE* stderr and keeps behavior the same.\n\nOpened by Javi’s Codex assistant.