### PR TITLE
chore: fix copyright year update invalid sequence error

### DIFF
--- a/Sources/Trimmy/SettingsAboutPane.swift
+++ b/Sources/Trimmy/SettingsAboutPane.swift
@@ -99,7 +99,7 @@ struct AboutPane: View {
                 }
             }
 
-            Text("\g<1>2026 Peter Steinberger. MIT License.")
+            Text("© 2026 Peter Steinberger. MIT License.")
                 .font(.footnote)
                 .foregroundStyle(.secondary)
                 .padding(.top, 4)


### PR DESCRIPTION
I was compiling to run the app locally and got this error (also seen in latest CI). `error: invalid escape sequence in literal` from string literal on copyright year change