### PR TITLE
feat: auto-quote paths with spaces for shell compatibility

### DIFF
--- a/Sources/Trimmy/ClipboardMonitor.swift
+++ b/Sources/Trimmy/ClipboardMonitor.swift
@@ -437,6 +437,11 @@ extension ClipboardMonitor {
             wasTransformed = true
         }
 
+        if let quotedPath = self.detector.quotePathWithSpaces(currentText) {
+            currentText = quotedPath
+            wasTransformed = true
+        }
+
         let isTerminal = sourceContext?.isTerminal == true
         let useTerminalAggressiveness = isTerminal && self.settings.contextAwareTrimmingEnabled
         let baseAggressiveness = useTerminalAggressiveness

--- a/Sources/Trimmy/CommandDetector.swift
+++ b/Sources/Trimmy/CommandDetector.swift
@@ -18,6 +18,10 @@ struct CommandDetector {
         self.cleaner.repairWrappedURL(text)
     }
 
+    func quotePathWithSpaces(_ text: String) -> String? {
+        self.cleaner.quotePathWithSpaces(text)
+    }
+
     func transformIfCommand(_ text: String, aggressivenessOverride: Aggressiveness? = nil) -> String? {
         let baseAggressiveness = self.settings.generalAggressiveness.coreAggressiveness
         guard let aggressiveness = aggressivenessOverride ?? baseAggressiveness else { return nil }

--- a/Tests/TrimmyTests/TrimmyTests.swift
+++ b/Tests/TrimmyTests/TrimmyTests.swift
@@ -649,4 +649,119 @@ struct TrimmyTests {
         """
         #expect(detector.stripPromptPrefixes(text) == nil)
     }
+
+    // MARK: - Path Quoting Tests
+
+    @Test
+    func quotesAbsolutePathWithSpaces() {
+        let settings = AppSettings()
+        let detector = CommandDetector(settings: settings)
+        let path = "/Users/anton/My Documents/project"
+        #expect(detector.quotePathWithSpaces(path) == "\"/Users/anton/My Documents/project\"")
+    }
+
+    @Test
+    func quotesHomeRelativePathWithSpaces() {
+        let settings = AppSettings()
+        let detector = CommandDetector(settings: settings)
+        let path = "~/Library/Application Support/SomeApp"
+        #expect(detector.quotePathWithSpaces(path) == "\"~/Library/Application Support/SomeApp\"")
+    }
+
+    @Test
+    func quotesCurrentDirRelativePathWithSpaces() {
+        let settings = AppSettings()
+        let detector = CommandDetector(settings: settings)
+        let path = "./My Project/src"
+        #expect(detector.quotePathWithSpaces(path) == "\"./My Project/src\"")
+    }
+
+    @Test
+    func quotesParentDirRelativePathWithSpaces() {
+        let settings = AppSettings()
+        let detector = CommandDetector(settings: settings)
+        let path = "../Other Project/lib"
+        #expect(detector.quotePathWithSpaces(path) == "\"../Other Project/lib\"")
+    }
+
+    @Test
+    func doesNotQuotePathWithoutSpaces() {
+        let settings = AppSettings()
+        let detector = CommandDetector(settings: settings)
+        let path = "/Users/anton/Documents/project"
+        #expect(detector.quotePathWithSpaces(path) == nil)
+    }
+
+    @Test
+    func doesNotQuoteAlreadyQuotedPath() {
+        let settings = AppSettings()
+        let detector = CommandDetector(settings: settings)
+        let path = "\"/Users/anton/My Documents/project\""
+        #expect(detector.quotePathWithSpaces(path) == nil)
+    }
+
+    @Test
+    func doesNotQuoteAlreadySingleQuotedPath() {
+        let settings = AppSettings()
+        let detector = CommandDetector(settings: settings)
+        let path = "'/Users/anton/My Documents/project'"
+        #expect(detector.quotePathWithSpaces(path) == nil)
+    }
+
+    @Test
+    func doesNotQuoteMultiLinePaths() {
+        let settings = AppSettings()
+        let detector = CommandDetector(settings: settings)
+        let path = "/Users/anton/My Documents\n/another/path"
+        #expect(detector.quotePathWithSpaces(path) == nil)
+    }
+
+    @Test
+    func doesNotQuoteCommandWithFlags() {
+        let settings = AppSettings()
+        let detector = CommandDetector(settings: settings)
+        // This looks like a command, not a path
+        let text = "/usr/bin/ls -la /some/path"
+        #expect(detector.quotePathWithSpaces(text) == nil)
+    }
+
+    @Test
+    func doesNotQuoteNonPathText() {
+        let settings = AppSettings()
+        let detector = CommandDetector(settings: settings)
+        let text = "just some text with spaces"
+        #expect(detector.quotePathWithSpaces(text) == nil)
+    }
+
+    @Test
+    func escapesExistingDoubleQuotesInPath() {
+        let settings = AppSettings()
+        let detector = CommandDetector(settings: settings)
+        let path = "/Users/anton/My \"Special\" Folder"
+        #expect(detector.quotePathWithSpaces(path) == "\"/Users/anton/My \\\"Special\\\" Folder\"")
+    }
+
+    @Test
+    func trimsWhitespaceBeforeQuoting() {
+        let settings = AppSettings()
+        let detector = CommandDetector(settings: settings)
+        let path = "  /Users/anton/My Documents/project  \n"
+        #expect(detector.quotePathWithSpaces(path) == "\"/Users/anton/My Documents/project\"")
+    }
+
+    @Test
+    func quotesRelativePathWithSpaces() {
+        let settings = AppSettings()
+        let detector = CommandDetector(settings: settings)
+        let path = "designcode.io/SwiftUI for iOS 17/Xcode Final/iOS17"
+        #expect(detector.quotePathWithSpaces(path) == "\"designcode.io/SwiftUI for iOS 17/Xcode Final/iOS17\"")
+    }
+
+    @Test
+    func doesNotQuoteURLs() {
+        let settings = AppSettings()
+        let detector = CommandDetector(settings: settings)
+        let url = "https://example.com/path with spaces"
+        #expect(detector.quotePathWithSpaces(url) == nil)
+    }
 }


### PR DESCRIPTION
## Summary

- Adds automatic quoting for filesystem paths containing spaces
- Paths like `/Users/name/My Documents` become `"/Users/name/My Documents"` when copied
- Works with absolute, home-relative (`~/`), and relative paths
- Solves the common pain of copying paths from ripgrep/grep output and pasting into `cd`

## Test plan

- [x] Copy path with spaces → gets quoted
- [x] Copy path without spaces → unchanged  
- [x] Copy already-quoted path → unchanged
- [x] Copy URL with spaces → unchanged (not treated as path)
- [x] Copy command with flags → unchanged
- [x] All 108 tests pass