### PR TITLE
feat: add configurable path suffix cleanup and heredoc formatting

### DIFF
--- a/Sources/Trimmy/AppSettings.swift
+++ b/Sources/Trimmy/AppSettings.swift
@@ -10,6 +10,9 @@ public final class AppSettings: ObservableObject {
     @AppStorage("autoTrimEnabled") public var autoTrimEnabled: Bool = true
     @AppStorage("contextAwareTrimmingEnabled") public var contextAwareTrimmingEnabled: Bool = true
     @AppStorage("removeBoxDrawing") public var removeBoxDrawing: Bool = true
+    @AppStorage("boxDrawingChars") public var boxDrawingChars: String = "│┃╎╏┆┇┊┋╽╿￨｜"
+    @AppStorage("trimPathSuffix") public var trimPathSuffix: Bool = true
+    @AppStorage("formatHeredoc") public var formatHeredoc: Bool = true
     @AppStorage("usePasteboardFallbacks") var usePasteboardFallbacks: Bool = false
     @AppStorage("showMarkdownReformatOption") var showMarkdownReformatOption: Bool = true
     @AppStorage("launchAtLogin") var launchAtLogin: Bool = false {

--- a/Sources/Trimmy/ClipboardMonitor.swift
+++ b/Sources/Trimmy/ClipboardMonitor.swift
@@ -467,11 +467,25 @@ extension ClipboardMonitor {
             wasTransformed = true
         }
 
+        if let cleanedPath = self.detector.cleanPathSuffix(currentText) {
+            currentText = cleanedPath
+            wasTransformed = true
+        }
+
         if let quotedPath = self.detector.quotePathWithSpaces(currentText) {
             currentText = quotedPath
             wasTransformed = true
         }
 
+        // Format heredoc blocks - must return early to preserve multi-line structure
+        if self.settings.formatHeredoc, let heredocFormatted = self.detector.formatHeredoc(currentText) {
+            currentText = heredocFormatted
+            wasTransformed = true
+            return ClipboardVariants(
+                original: text,
+                trimmed: currentText,
+                wasTransformed: wasTransformed)
+        }
         let isTerminal = sourceContext?.isTerminal == true
         let useTerminalAggressiveness = isTerminal && self.settings.contextAwareTrimmingEnabled
         let baseAggressiveness = useTerminalAggressiveness

--- a/Sources/Trimmy/CommandDetector.swift
+++ b/Sources/Trimmy/CommandDetector.swift
@@ -7,7 +7,10 @@ struct CommandDetector {
     private let cleaner = TextCleaner()
 
     func cleanBoxDrawingCharacters(_ text: String) -> String? {
-        self.cleaner.cleanBoxDrawingCharacters(text, enabled: self.settings.removeBoxDrawing)
+        self.cleaner.cleanBoxDrawingCharacters(
+            text,
+            enabled: self.settings.removeBoxDrawing,
+            chars: self.settings.boxDrawingChars)
     }
 
     func stripPromptPrefixes(_ text: String) -> String? {
@@ -20,6 +23,14 @@ struct CommandDetector {
 
     func quotePathWithSpaces(_ text: String) -> String? {
         self.cleaner.quotePathWithSpaces(text)
+    }
+
+    func formatHeredoc(_ text: String) -> String? {
+        self.cleaner.formatHeredoc(text)
+    }
+
+    func cleanPathSuffix(_ text: String) -> String? {
+        self.cleaner.cleanPathSuffix(text, enabled: self.settings.trimPathSuffix)
     }
 
     func transformIfCommand(_ text: String, aggressivenessOverride: Aggressiveness? = nil) -> String? {
@@ -52,6 +63,9 @@ struct CommandDetector {
         TrimConfig(
             aggressiveness: aggressiveness,
             preserveBlankLines: self.settings.preserveBlankLines,
-            removeBoxDrawing: self.settings.removeBoxDrawing)
+            removeBoxDrawing: self.settings.removeBoxDrawing,
+            boxDrawingChars: self.settings.boxDrawingChars,
+            trimPathSuffix: self.settings.trimPathSuffix,
+            formatHeredoc: self.settings.formatHeredoc)
     }
 }

--- a/Sources/Trimmy/SettingsGeneralPane.swift
+++ b/Sources/Trimmy/SettingsGeneralPane.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import TrimmyCore
 
 @MainActor
 struct GeneralSettingsPane: View {
@@ -28,9 +29,35 @@ struct GeneralSettingsPane: View {
                 binding: self.$settings.preserveBlankLines)
 
             PreferenceToggleRow(
-                title: "Remove box drawing chars (│┃)",
+                title: "Remove box drawing chars",
                 subtitle: "Strip prompt-style box gutters (any count, leading/trailing) before trimming.",
                 binding: self.$settings.removeBoxDrawing)
+
+            if self.settings.removeBoxDrawing {
+                HStack(alignment: .top, spacing: 8) {
+                    Text("Chars:")
+                        .foregroundStyle(.secondary)
+                        .frame(width: 50, alignment: .trailing)
+                    TextField("Box chars", text: self.$settings.boxDrawingChars)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(maxWidth: 200)
+                    Button("Reset") {
+                        self.settings.boxDrawingChars = TrimConfig.defaultBoxDrawingChars
+                    }
+                    .buttonStyle(.borderless)
+                }
+                .padding(.leading, 28)
+            }
+
+            PreferenceToggleRow(
+                title: "Clean path suffix",
+                subtitle: "Remove trailing colon and line numbers from paths (e.g., /path/file.swift:42: → /path/file.swift).",
+                binding: self.$settings.trimPathSuffix)
+
+            PreferenceToggleRow(
+                title: "Format heredoc blocks",
+                subtitle: "Fix indentation and ensure EOF delimiter is at line start for shell heredoc syntax.",
+                binding: self.$settings.formatHeredoc)
 
             PreferenceToggleRow(
                 title: "Show Markdown reformat option",

--- a/Sources/TrimmyCore/TextCleaner.swift
+++ b/Sources/TrimmyCore/TextCleaner.swift
@@ -7,7 +7,6 @@ public struct TrimResult: Sendable {
 }
 
 public struct TextCleaner: Sendable {
-    private static let boxDrawingCharacterClass = "[│┃╎╏┆┇┊┋╽╿￨｜]"
     private static let knownCommandPrefixes: [String] = [
         "sudo", "./", "~/", "apt", "brew", "git", "python", "pip", "pnpm", "npm", "yarn", "cargo",
         "bundle", "rails", "go", "make", "xcodebuild", "swift", "kubectl", "docker", "podman", "aws",
@@ -17,9 +16,9 @@ public struct TextCleaner: Sendable {
 
     public init() {}
 
-    public func cleanBoxDrawingCharacters(_ text: String, enabled: Bool) -> String? {
-        guard enabled else { return nil }
-        return Self.stripBoxDrawingCharacters(in: text)
+    public func cleanBoxDrawingCharacters(_ text: String, enabled: Bool, chars: String) -> String? {
+        guard enabled, !chars.isEmpty else { return nil }
+        return Self.stripBoxDrawingCharacters(in: text, chars: chars)
     }
 
     public func repairWrappedURL(_ text: String) -> String? {
@@ -92,6 +91,34 @@ public struct TextCleaner: Sendable {
         return "\"\(escaped)\""
     }
 
+    /// Removes trailing colon (and optional line:column suffix) from file paths.
+    /// e.g., "/path/to/file.swift:" → "/path/to/file.swift"
+    /// e.g., "/path/to/file.swift:42:" → "/path/to/file.swift"
+    /// e.g., "/path/to/file.swift:42:10:" → "/path/to/file.swift"
+    public func cleanPathSuffix(_ text: String, enabled: Bool) -> String? {
+        guard enabled else { return nil }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Must be single line
+        guard !trimmed.contains("\n") else { return nil }
+
+        // Pattern: path followed by optional :line:col and trailing colon
+        // Matches: /path/file:  or  /path/file:42:  or  /path/file:42:10:
+        let pathPattern = #"^([/~][\S]*?)(:\d+)?(:\d+)?:$"#
+        guard trimmed.range(of: pathPattern, options: .regularExpression) != nil else {
+            return nil
+        }
+
+        // Extract just the path (without line:col suffix)
+        let result = trimmed.replacingOccurrences(
+            of: pathPattern,
+            with: "$1",
+            options: .regularExpression
+        )
+
+        return result == trimmed ? nil : result
+    }
+
     // MARK: - Public pipeline
 
     public func transform(
@@ -102,7 +129,11 @@ public struct TextCleaner: Sendable {
         var currentText = text
         var wasTransformed = false
 
-        if let cleaned = self.cleanBoxDrawingCharacters(currentText, enabled: config.removeBoxDrawing) {
+        if let cleaned = self.cleanBoxDrawingCharacters(
+            currentText,
+            enabled: config.removeBoxDrawing,
+            chars: config.boxDrawingChars)
+        {
             currentText = cleaned
             wasTransformed = true
         }
@@ -117,11 +148,23 @@ public struct TextCleaner: Sendable {
             wasTransformed = true
         }
 
+        if let cleanedPath = self.cleanPathSuffix(currentText, enabled: config.trimPathSuffix) {
+            currentText = cleanedPath
+            wasTransformed = true
+        }
+
         if let quotedPath = self.quotePathWithSpaces(currentText) {
             currentText = quotedPath
             wasTransformed = true
         }
 
+        // Format heredoc blocks (must come before flatten to preserve structure)
+        if config.formatHeredoc, let heredocFormatted = self.formatHeredoc(currentText) {
+            currentText = heredocFormatted
+            wasTransformed = true
+            // Return early - don't flatten heredoc
+            return TrimResult(original: text, trimmed: currentText, wasTransformed: wasTransformed)
+        }
         if let commandTransformed = self.transformIfCommand(
             currentText,
             config: config,
@@ -401,8 +444,17 @@ public struct TextCleaner: Sendable {
 
     // MARK: - Box drawing cleanup (shared)
 
-    public static func stripBoxDrawingCharacters(in text: String) -> String? {
-        let boxRegex = try? NSRegularExpression(pattern: self.boxDrawingCharacterClass, options: [])
+    public static func stripBoxDrawingCharacters(
+        in text: String,
+        chars: String = TrimConfig.defaultBoxDrawingChars) -> String?
+    {
+        guard !chars.isEmpty else { return nil }
+
+        // Build character class from the configurable chars string
+        let escapedChars = NSRegularExpression.escapedPattern(for: chars)
+        let charClass = "[\(escapedChars)]"
+
+        let boxRegex = try? NSRegularExpression(pattern: charClass, options: [])
         if boxRegex?.firstMatch(in: text, options: [], range: NSRange(location: 0, length: text.utf16.count)) == nil {
             return nil
         }
@@ -415,10 +467,8 @@ public struct TextCleaner: Sendable {
         let lines = result.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
         let nonEmptyLines = lines.filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
         if !nonEmptyLines.isEmpty {
-            let leadingPattern =
-                #"^\s*\#(boxDrawingCharacterClass)+ ?"#
-            let trailingPattern =
-                #" ?\#(boxDrawingCharacterClass)+\s*$"#
+            let leadingPattern = "^\\s*\(charClass)+ ?"
+            let trailingPattern = " ?\(charClass)+\\s*$"
             let majorityThreshold = nonEmptyLines.count / 2 + 1
 
             let leadingMatches = nonEmptyLines.count(where: {
@@ -456,26 +506,26 @@ public struct TextCleaner: Sendable {
             }
         }
 
-        let boxAfterPipePattern = #"\|\s*\#(boxDrawingCharacterClass)+\s*"#
+        let boxAfterPipePattern = "\\|\\s*\(charClass)+\\s*"
         result = result.replacingOccurrences(
             of: boxAfterPipePattern,
             with: "| ",
             options: .regularExpression)
 
-        let boxPathJoinPattern = #"([:/])\s*\#(boxDrawingCharacterClass)+\s*([A-Za-z0-9])"#
+        let boxPathJoinPattern = "([:/])\\s*\(charClass)+\\s*([A-Za-z0-9])"
         result = result.replacingOccurrences(
             of: boxPathJoinPattern,
             with: "$1$2",
             options: .regularExpression)
 
-        let boxMidTokenPattern = #"(\S)\s*\#(boxDrawingCharacterClass)+\s*(\S)"#
+        let boxMidTokenPattern = "(\\S)\\s*\(charClass)+\\s*(\\S)"
         result = result.replacingOccurrences(
             of: boxMidTokenPattern,
             with: "$1 $2",
             options: .regularExpression)
 
         result = result.replacingOccurrences(
-            of: #"\s*\#(self.boxDrawingCharacterClass)+\s*"#,
+            of: "\\s*\(charClass)+\\s*",
             with: " ",
             options: .regularExpression)
 
@@ -485,6 +535,86 @@ public struct TextCleaner: Sendable {
             options: .regularExpression)
         let trimmed = collapsed.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed == text ? nil : trimmed
+    }
+
+    // MARK: - Heredoc formatting
+
+    /// Formats heredoc blocks by removing common indentation and fixing the delimiter line.
+    /// Returns nil if text doesn't contain a heredoc pattern.
+    public func formatHeredoc(_ text: String) -> String? {
+        // Pattern: << or <<- followed by optional quotes and a word
+        let pattern = #"<<-?\s*['"]?([A-Za-z_][A-Za-z0-9_]*)['"]?"#
+        guard text.range(of: pattern, options: .regularExpression) != nil else {
+            return nil
+        }
+
+        // Extract the delimiter word (e.g., EOF)
+        let nsText = text as NSString
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let nsMatch = regex.firstMatch(in: text, range: NSRange(location: 0, length: nsText.length)),
+              nsMatch.numberOfRanges >= 2
+        else {
+            return nil
+        }
+        let delimiterRange = nsMatch.range(at: 1)
+        let delimiter = nsText.substring(with: delimiterRange)
+
+        // Split into lines
+        let lines = text.components(separatedBy: "\n")
+        guard lines.count >= 2 else { return nil }
+
+        // Find the delimiter line (end marker)
+        guard let endIndex = lines.lastIndex(where: {
+            $0.trimmingCharacters(in: .whitespaces) == delimiter
+        }), endIndex > 0 else {
+            return nil
+        }
+
+        // Find the start line (contains << DELIMITER)
+        guard let startIndex = lines.firstIndex(where: {
+            $0.range(of: pattern, options: .regularExpression) != nil
+        }), startIndex < endIndex else {
+            return nil
+        }
+
+        // Content lines are between start and end
+        let contentRange = (startIndex + 1)..<endIndex
+
+        // Calculate minimum common indentation for content lines
+        var minIndent = Int.max
+        for i in contentRange {
+            let line = lines[i]
+            if line.trimmingCharacters(in: .whitespaces).isEmpty { continue }
+            let leadingSpaces = line.prefix(while: { $0 == " " || $0 == "\t" }).count
+            minIndent = min(minIndent, leadingSpaces)
+        }
+        if minIndent == Int.max { minIndent = 0 }
+
+        // Also check start line for indentation
+        let startLineIndent = lines[startIndex].prefix(while: { $0 == " " || $0 == "\t" }).count
+        minIndent = min(minIndent, startLineIndent)
+
+        // Apply formatting
+        var result = lines
+
+        // Remove common indentation from start line
+        if startLineIndent >= minIndent {
+            result[startIndex] = String(lines[startIndex].dropFirst(minIndent))
+        }
+
+        // Remove common indentation from content lines
+        for i in contentRange {
+            let line = lines[i]
+            if line.count >= minIndent {
+                result[i] = String(line.dropFirst(minIndent))
+            }
+        }
+
+        // Fix end line: remove ALL leading whitespace
+        result[endIndex] = lines[endIndex].trimmingCharacters(in: .init(charactersIn: " \t"))
+
+        let formatted = result.joined(separator: "\n")
+        return formatted == text ? nil : formatted
     }
 
     // MARK: - Prompt stripping helpers

--- a/Sources/TrimmyCore/TrimConfig.swift
+++ b/Sources/TrimmyCore/TrimConfig.swift
@@ -4,14 +4,25 @@ public struct TrimConfig: Sendable {
     public var aggressiveness: Aggressiveness
     public var preserveBlankLines: Bool
     public var removeBoxDrawing: Bool
+    public var boxDrawingChars: String
+    public var trimPathSuffix: Bool
+    public var formatHeredoc: Bool
+
+    public static let defaultBoxDrawingChars = "│┃╎╏┆┇┊┋╽╿￨｜"
 
     public init(
         aggressiveness: Aggressiveness,
         preserveBlankLines: Bool,
-        removeBoxDrawing: Bool)
+        removeBoxDrawing: Bool,
+        boxDrawingChars: String = TrimConfig.defaultBoxDrawingChars,
+        trimPathSuffix: Bool = true,
+        formatHeredoc: Bool = true)
     {
         self.aggressiveness = aggressiveness
         self.preserveBlankLines = preserveBlankLines
         self.removeBoxDrawing = removeBoxDrawing
+        self.boxDrawingChars = boxDrawingChars
+        self.trimPathSuffix = trimPathSuffix
+        self.formatHeredoc = formatHeredoc
     }
 }

--- a/Tests/TrimmyTests/TrimmyTests.swift
+++ b/Tests/TrimmyTests/TrimmyTests.swift
@@ -788,4 +788,138 @@ struct TrimmyTests {
         let url = "https://example.com/path with spaces"
         #expect(detector.quotePathWithSpaces(url) == nil)
     }
+
+    // MARK: - Heredoc formatting tests
+
+    @Test
+    func formatsHeredocRemovesCommonIndent() {
+        let settings = AppSettings()
+        let detector = CommandDetector(settings: settings)
+        let input = "  cat > file.txt << 'EOF'\n  line 1\n  line 2\n  EOF"
+        let expected = "cat > file.txt << 'EOF'\nline 1\nline 2\nEOF"
+        #expect(detector.formatHeredoc(input) == expected)
+    }
+
+    @Test
+    func formatsHeredocFixesEndMarker() {
+        let settings = AppSettings()
+        let detector = CommandDetector(settings: settings)
+        let input = "cat << EOF\ncontent\n  EOF"
+        let expected = "cat << EOF\ncontent\nEOF"
+        #expect(detector.formatHeredoc(input) == expected)
+    }
+
+    @Test
+    func formatsHeredocPreservesRelativeIndent() {
+        let settings = AppSettings()
+        let detector = CommandDetector(settings: settings)
+        let input = "  cat << EOF\n    outer\n      inner\n  EOF"
+        let expected = "cat << EOF\n  outer\n    inner\nEOF"
+        #expect(detector.formatHeredoc(input) == expected)
+    }
+
+    @Test
+    func formatsHeredocWithDoubleQuotes() {
+        let settings = AppSettings()
+        let detector = CommandDetector(settings: settings)
+        let input = "  cat << \"END\"\n  some content\n  END"
+        let expected = "cat << \"END\"\nsome content\nEND"
+        #expect(detector.formatHeredoc(input) == expected)
+    }
+
+    @Test
+    func formatsHeredocWithDash() {
+        let settings = AppSettings()
+        let detector = CommandDetector(settings: settings)
+        let input = "  cat <<- EOF\n  \tindented\n  EOF"
+        let expected = "cat <<- EOF\n\tindented\nEOF"
+        #expect(detector.formatHeredoc(input) == expected)
+    }
+
+    @Test
+    func heredocReturnsNilWhenNoHeredocPresent() {
+        let settings = AppSettings()
+        let detector = CommandDetector(settings: settings)
+        let input = "echo hello\nworld"
+        #expect(detector.formatHeredoc(input) == nil)
+    }
+
+    @Test
+    func heredocReturnsNilWhenAlreadyFormatted() {
+        let settings = AppSettings()
+        let detector = CommandDetector(settings: settings)
+        let input = "cat << EOF\ncontent\nEOF"
+        #expect(detector.formatHeredoc(input) == nil)
+    }
+
+    @Test
+    func heredocNotFlattenedAfterFormat() {
+        let settings = AppSettings()
+        settings.generalAggressiveness = .high
+        let cleaner = TextCleaner()
+        let config = TrimConfig(aggressiveness: .high, preserveBlankLines: false, removeBoxDrawing: false)
+        let input = "  cat > test.txt << 'EOF'\n  hello\n  world\n  EOF"
+        let result = cleaner.transform(input, config: config)
+        #expect(result.trimmed.contains("\n"))
+        #expect(result.trimmed.hasSuffix("EOF"))
+        #expect(result.wasTransformed == true)
+    }
+
+    // MARK: - Path suffix cleanup tests
+
+    @Test
+    func cleansPathWithTrailingColon() {
+        let settings = AppSettings()
+        settings.trimPathSuffix = true
+        let detector = CommandDetector(settings: settings)
+        #expect(detector.cleanPathSuffix("/Applications/Trimmy.app:") == "/Applications/Trimmy.app")
+    }
+
+    @Test
+    func cleansPathWithLineNumber() {
+        let settings = AppSettings()
+        settings.trimPathSuffix = true
+        let detector = CommandDetector(settings: settings)
+        #expect(detector.cleanPathSuffix("/path/to/file.swift:42:") == "/path/to/file.swift")
+    }
+
+    @Test
+    func cleansPathWithLineAndColumn() {
+        let settings = AppSettings()
+        settings.trimPathSuffix = true
+        let detector = CommandDetector(settings: settings)
+        #expect(detector.cleanPathSuffix("/path/to/file.swift:42:10:") == "/path/to/file.swift")
+    }
+
+    @Test
+    func cleansHomePath() {
+        let settings = AppSettings()
+        settings.trimPathSuffix = true
+        let detector = CommandDetector(settings: settings)
+        #expect(detector.cleanPathSuffix("~/Documents/file.txt:") == "~/Documents/file.txt")
+    }
+
+    @Test
+    func pathCleanupReturnsNilWhenDisabled() {
+        let settings = AppSettings()
+        settings.trimPathSuffix = false
+        let detector = CommandDetector(settings: settings)
+        #expect(detector.cleanPathSuffix("/path/to/file:") == nil)
+    }
+
+    @Test
+    func pathCleanupReturnsNilForNonPath() {
+        let settings = AppSettings()
+        settings.trimPathSuffix = true
+        let detector = CommandDetector(settings: settings)
+        #expect(detector.cleanPathSuffix("not a path:") == nil)
+    }
+
+    @Test
+    func pathCleanupReturnsNilWhenNoTrailingColon() {
+        let settings = AppSettings()
+        settings.trimPathSuffix = true
+        let detector = CommandDetector(settings: settings)
+        #expect(detector.cleanPathSuffix("/path/to/file") == nil)
+    }
 }


### PR DESCRIPTION
## Summary
- add `trimPathSuffix` and `formatHeredoc` settings in General preferences
- implement path suffix cleanup (e.g. `/path/file.swift:42:` -> `/path/file.swift`)
- implement heredoc block formatting with early return to preserve multiline structure
- keep existing path quoting behavior and merge all related transformations in pipeline
- add test coverage for path quoting, heredoc formatting, and path suffix cleanup

## Validation
- `swift test` passes locally
- `pnpm check` currently fails on repository-wide baseline SwiftFormat issues in untouched files
