### PR TITLE
fix: dedent copied prose paragraphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Claude Code: add optional prompt-decoration flattening for copied slash commands while preserving ordinary wrapped prose (#19, thanks @evoleinik).
 - Settings: add an option to hide the menu bar icon while keeping Trimmy running (#24, thanks @qazi0).
+- Text cleanup: dedent copied prose where most paragraph lines share the same leading whitespace (#10, thanks @arunsathiya).
 
 ## 0.8.0 — 2026-01-19
 - Added a menu-only “Paste Reformatted Markdown” action to join wrapped markdown paragraphs and bullet lists while preserving blank lines and fenced code blocks.

--- a/Sources/Trimmy/ClipboardMonitor.swift
+++ b/Sources/Trimmy/ClipboardMonitor.swift
@@ -506,6 +506,11 @@ extension ClipboardMonitor {
             wasTransformed = true
         }
 
+        if let dedentedParagraph = self.detector.dedentParagraphIndent(currentText) {
+            currentText = dedentedParagraph
+            wasTransformed = true
+        }
+
         return ClipboardVariants(
             original: text,
             trimmed: currentText,

--- a/Sources/Trimmy/CommandDetector.swift
+++ b/Sources/Trimmy/CommandDetector.swift
@@ -26,6 +26,10 @@ struct CommandDetector {
         self.cleaner.quotePathWithSpaces(text)
     }
 
+    func dedentParagraphIndent(_ text: String) -> String? {
+        self.cleaner.dedentParagraphIndent(text)
+    }
+
     func transformIfCommand(_ text: String, aggressivenessOverride: Aggressiveness? = nil) -> String? {
         let baseAggressiveness = self.settings.generalAggressiveness.coreAggressiveness
         guard let aggressiveness = aggressivenessOverride ?? baseAggressiveness else { return nil }

--- a/Sources/TrimmyCore/TextCleaner.swift
+++ b/Sources/TrimmyCore/TextCleaner.swift
@@ -97,6 +97,51 @@ public struct TextCleaner: Sendable {
         return "\"\(escaped)\""
     }
 
+    /// Removes shared leading indentation from prose paragraphs while avoiding code, lists, and commands.
+    public func dedentParagraphIndent(_ text: String) -> String? {
+        guard text.contains(where: \.isNewline) else { return nil }
+
+        let lines = text.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline).map(String.init)
+        let nonEmptyIndices = lines.indices.filter {
+            !lines[$0].trimmingCharacters(in: .whitespaces).isEmpty
+        }
+        guard nonEmptyIndices.count >= 2 else { return nil }
+
+        let nonEmptyLines = nonEmptyIndices.map { lines[$0][...] }
+        guard !self.isLikelyList(nonEmptyLines),
+              !self.isLikelySourceCode(text),
+              !self.isLikelyStructuredData(nonEmptyLines),
+              !self.hasCommandPunctuation(text)
+        else {
+            return nil
+        }
+
+        let indentedProseLines = nonEmptyIndices.compactMap { index -> Int? in
+            let line = lines[index]
+            let indent = line.prefix(while: \.isWhitespace).count
+            guard indent > 0 else { return nil }
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard self.isLikelyProseLine(trimmed) else { return nil }
+            return indent
+        }
+
+        let requiredIndentedLines = max(2, nonEmptyIndices.count / 2 + 1)
+        guard indentedProseLines.count >= requiredIndentedLines,
+              let commonIndent = indentedProseLines.min(),
+              commonIndent > 0
+        else {
+            return nil
+        }
+
+        let dedented = lines.map { line -> String in
+            let indent = line.prefix(while: \.isWhitespace).count
+            guard indent >= commonIndent else { return line }
+            return String(line.dropFirst(commonIndent))
+        }.joined(separator: "\n")
+
+        return dedented == text ? nil : dedented
+    }
+
     // MARK: - Public pipeline
 
     public func transform(
@@ -138,6 +183,11 @@ public struct TextCleaner: Sendable {
             aggressivenessOverride: aggressivenessOverride)
         {
             currentText = commandTransformed
+            wasTransformed = true
+        }
+
+        if let dedentedParagraph = self.dedentParagraphIndent(currentText) {
+            currentText = dedentedParagraph
             wasTransformed = true
         }
 
@@ -351,6 +401,31 @@ public struct TextCleaner: Sendable {
         if text.contains("<") || text.contains(">") { return true }
 
         return false
+    }
+
+    private func isLikelyProseLine(_ line: String) -> Bool {
+        guard let first = line.first, first.isLetter || "\"'(".contains(first) else { return false }
+        if line.range(of: #"^[-*•]|^[0-9]+[.)]\s|^(?:\$|#|>|[|&;{}])"#, options: .regularExpression) != nil {
+            return false
+        }
+        if line.range(of: #"^["'][^"']+["']\s*:"#, options: .regularExpression) != nil {
+            return false
+        }
+        if line.range(
+            of: #"^(?:sudo|git|npm|pnpm|yarn|swift|xcodebuild|docker|kubectl|cd|ls|cat|echo|make)\b"#,
+            options: [.regularExpression, .caseInsensitive]) != nil
+        {
+            return false
+        }
+        return line.contains(where: \.isWhitespace) || line.range(of: #"[,.!?;:]"#, options: .regularExpression) != nil
+    }
+
+    private func isLikelyStructuredData(_ lines: [Substring]) -> Bool {
+        lines.contains { line in
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if ["{", "}", "[", "]"].contains(trimmed) { return true }
+            return trimmed.range(of: #"^["'][^"']+["']\s*:"#, options: .regularExpression) != nil
+        }
     }
 
     private func isLikelyList(_ lines: [Substring]) -> Bool {

--- a/Tests/TrimmyCLITests/TrimmyCLITests.swift
+++ b/Tests/TrimmyCLITests/TrimmyCLITests.swift
@@ -42,6 +42,24 @@ struct TrimmyCLITests {
     }
 
     @Test
+    func `dedents prose copied with shared indentation`() {
+        let input = """
+        Hello,
+         This paragraph line has accidental indentation.
+         This one does too.
+        """
+        let expected = """
+        Hello,
+        This paragraph line has accidental indentation.
+        This one does too.
+        """
+
+        let result = cliTrim(input, settings: CLISettings(), force: false)
+        #expect(result.transformed)
+        #expect(result.trimmed == expected)
+    }
+
+    @Test
     func `ignores structured json`() {
         let input = """
         {

--- a/Tests/TrimmyTests/ParagraphDedentTests.swift
+++ b/Tests/TrimmyTests/ParagraphDedentTests.swift
@@ -1,0 +1,118 @@
+import Testing
+@testable import Trimmy
+@testable import TrimmyCore
+
+@MainActor
+struct ParagraphDedentTests {
+    private let cleaner = TextCleaner()
+
+    @Test
+    func `dedents copied prose with shared paragraph indentation`() {
+        let input = """
+        Hi Sarah,
+
+         Thanks for getting back to me so quickly!
+
+         I wanted to follow up on our earlier conversation about the project timeline.
+
+         Let me know if you have any questions.
+        """
+
+        let expected = """
+        Hi Sarah,
+
+        Thanks for getting back to me so quickly!
+
+        I wanted to follow up on our earlier conversation about the project timeline.
+
+        Let me know if you have any questions.
+        """
+
+        #expect(self.cleaner.dedentParagraphIndent(input) == expected)
+    }
+
+    @Test
+    func `dedents all indented prose lines by common indent only`() {
+        let input = """
+          First paragraph line.
+            Nested detail stays relatively indented.
+          Final paragraph line.
+        """
+
+        let expected = """
+        First paragraph line.
+          Nested detail stays relatively indented.
+        Final paragraph line.
+        """
+
+        #expect(self.cleaner.dedentParagraphIndent(input) == expected)
+    }
+
+    @Test
+    func `does not dedent bullet lists`() {
+        let input = """
+          - first item
+          - second item
+          - third item
+        """
+
+        #expect(self.cleaner.dedentParagraphIndent(input) == nil)
+    }
+
+    @Test
+    func `does not dedent source code`() {
+        let input = """
+          struct Example {
+              let value = 1
+          }
+        """
+
+        #expect(self.cleaner.dedentParagraphIndent(input) == nil)
+    }
+
+    @Test
+    func `does not dedent structured json`() {
+        let input = """
+          {
+            "name": "Trimmy",
+            "enabled": true
+          }
+        """
+
+        #expect(self.cleaner.dedentParagraphIndent(input) == nil)
+    }
+
+    @Test
+    func `does not run before command flattening`() {
+        let config = TrimConfig(
+            aggressiveness: .normal,
+            preserveBlankLines: false,
+            removeBoxDrawing: true)
+        let input = """
+        echo hello \\
+          && echo world
+        """
+
+        let result = self.cleaner.transform(input, config: config)
+        #expect(result.trimmed == "echo hello && echo world")
+    }
+
+    @Test
+    func `clipboard detector exposes paragraph dedent`() {
+        let settings = AppSettings()
+        let detector = CommandDetector(settings: settings)
+        let input = """
+        Hello,
+         This line has accidental indent.
+         This one too.
+        """
+
+        let expected = """
+        Hello,
+        This line has accidental indent.
+        This one too.
+        """
+
+        #expect(detector.dedentParagraphIndent(input) == expected)
+    }
+}


### PR DESCRIPTION
Fixes #10.

Summary:
- add a core prose-dedent heuristic that removes shared leading whitespace when most paragraph lines are indented
- run it through app clipboard transforms and TrimmyCLI after command flattening, so command snippets keep the existing path
- skip lists, source/code-ish text, and structured data such as JSON
- add app/core and CLI regression coverage
- update CHANGELOG.md

Local proof:
- swiftformat Sources Tests --lint
- swiftlint --strict
- pnpm check
- swift test --parallel
- swift build -c release --product TrimmyCLI --static-swift-stdlib
- ./Scripts/compile_and_run.sh