### PR TITLE
Add cmux to terminal app detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.10.2 — Unreleased
+- Terminal detection now recognizes cmux by bundle identifier and app name, so copies use terminal-specific trimming (thanks @gustavosmendes).
 
 ## 0.10.1 — 2026-06-11
 - Settings: reorganize controls into focused General, Trimming, Rules, Shortcuts, Advanced, and About tabs, with low-frequency cleanup options under Advanced and a compact native macOS layout.

--- a/Sources/Trimmy/TerminalAppIdentifiers.swift
+++ b/Sources/Trimmy/TerminalAppIdentifiers.swift
@@ -11,6 +11,7 @@ enum TerminalAppIdentifiers {
         "org.alacritty",
         "co.zeit.hyper",
         "net.kovidgoyal.kitty",
+        "com.cmuxterm.app",
     ]
 
     static let bundleIdentifierPrefixes: [String] = [
@@ -26,6 +27,7 @@ enum TerminalAppIdentifiers {
         "alacritty",
         "hyper",
         "kitty",
+        "cmux",
     ]
 
     static func isTerminal(bundleIdentifier: String?, appName: String?) -> Bool {

--- a/Tests/TrimmyTests/TerminalAppIdentifiersTests.swift
+++ b/Tests/TrimmyTests/TerminalAppIdentifiersTests.swift
@@ -1,0 +1,14 @@
+import Testing
+@testable import Trimmy
+
+struct TerminalAppIdentifiersTests {
+    @Test
+    func `detects cmux bundle identifier`() {
+        #expect(TerminalAppIdentifiers.isTerminal(bundleIdentifier: "com.cmuxterm.app", appName: nil))
+    }
+
+    @Test
+    func `detects cmux app name fallback`() {
+        #expect(TerminalAppIdentifiers.isTerminal(bundleIdentifier: nil, appName: "cmux"))
+    }
+}


### PR DESCRIPTION
## What

Add [cmux](https://github.com/steipete/cmux) to terminal app detection in `TerminalAppIdentifiers`.

## Why

cmux is a terminal emulator, but its bundle identifier `com.cmuxterm.app` was not in `exactBundleIdentifiers`, so `isTerminal(...)` returned `false` for it. Copies made inside cmux were therefore classified as **general-app** copies and trimmed with the *General* aggressiveness level (and skipped when General is set to *None*), instead of the *Terminal* level. In practice this meant terminal snippets copied in cmux were under-trimmed.

## Change

- Add the exact bundle id `com.cmuxterm.app` to `exactBundleIdentifiers`.
- Add a `"cmux"` entry to `nameHints` as a belt-and-suspenders fallback.
- Add focused tests for both the exact bundle identifier and app-name fallback.
- Add an Unreleased changelog entry.

```swift
static func isTerminal(...) // "com.cmuxterm.app" -> true
```

## Validation

- Bundle id confirmed on macOS: `mdls`/`Info.plist` of `/Applications/cmux.app` → `CFBundleIdentifier = com.cmuxterm.app`.
- `swift test --filter TerminalAppIdentifiersTests` — 2 passed, 0 failed.
- Full `swift test` — 175 passed, 0 failed.
- `pnpm check` — SwiftFormat and SwiftLint clean.
- Codex autoreview — no accepted/actionable findings.

### Live cmux proof

Used the PR build with General aggressiveness set to **None**, Terminal aggressiveness set to **Normal**, context-aware trimming enabled, and cmux as the active application. A two-line command was copied from cmux:

```text
echo trimmy-cmux-proof \
  --flag live
```

After Trimmy processed the clipboard, `pbpaste` returned:

```text
echo trimmy-cmux-proof --flag live
```

This differential setup only transforms the copy when cmux is classified as a terminal. Test settings were restored afterward. The debug build and full test suite passed; packaging reached the signing step but could not use the unavailable local Developer ID identity, so live validation used `.build/debug/Trimmy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
