### PR TITLE
chore(deps): update KeyboardShortcuts to 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.10.2 — Unreleased
 - Terminal detection now recognizes cmux by bundle identifier and app name, so copies use terminal-specific trimming (thanks @gustavosmendes).
+- Dependencies: update KeyboardShortcuts to 3.0.1 for Swift 6.3 release-build compatibility and shortcut-recorder fixes.
 
 ## 0.10.1 — 2026-06-11
 - Settings: reorganize controls into focused General, Trimming, Rules, Shortcuts, Advanced, and About tabs, with low-frequency cleanup options under Advanced and a compact native macOS layout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.10.2 — Unreleased
 - Terminal detection now recognizes cmux by bundle identifier and app name, so copies use terminal-specific trimming (thanks @gustavosmendes).
-- Dependencies: update KeyboardShortcuts to 3.0.1 for Swift 6.3 release-build compatibility and shortcut-recorder fixes.
+- Dependencies: update KeyboardShortcuts to 2.4.0 for shortcut-recorder fixes while preserving Swift 6.2 compatibility.
 
 ## 0.10.1 — 2026-06-11
 - Settings: reorganize controls into focused General, Trimming, Rules, Shortcuts, Advanced, and About tabs, with low-frequency cleanup options under Advanced and a compact native macOS layout.

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "387471814d8ac1ecac0b13a54992ba44a272bc1869aec47879425c9b92539e39",
+  "originHash" : "32c4e935d1a5dee34b726a10b9a8caf866ddc86985d4ab171f49ebe4e6a38616",
   "pins" : [
     {
       "identity" : "keyboardshortcuts",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sindresorhus/KeyboardShortcuts",
       "state" : {
-        "revision" : "ac12762853126cf2e7ad63a6a58e1c9f58c6a0ee",
-        "version" : "1.17.0"
+        "revision" : "49c3fc04ea827f816df67843bfcc57286b47ff06",
+        "version" : "3.0.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "32c4e935d1a5dee34b726a10b9a8caf866ddc86985d4ab171f49ebe4e6a38616",
+  "originHash" : "74ae3a7dad7f4741a344505f2f9b029dc105f9dce7df8e9f4bb304406f96f7af",
   "pins" : [
     {
       "identity" : "keyboardshortcuts",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sindresorhus/KeyboardShortcuts",
       "state" : {
-        "revision" : "49c3fc04ea827f816df67843bfcc57286b47ff06",
-        "version" : "3.0.1"
+        "revision" : "1aef85578fdd4f9eaeeb8d53b7b4fc31bf08fe27",
+        "version" : "2.4.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.3"),
-        .package(url: "https://github.com/sindresorhus/KeyboardShortcuts", from: "1.17.0"),
+        .package(url: "https://github.com/sindresorhus/KeyboardShortcuts", from: "3.0.1"),
         .package(url: "https://github.com/orchetect/MenuBarExtraAccess", exact: "1.3.0"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.3"),
-        .package(url: "https://github.com/sindresorhus/KeyboardShortcuts", from: "3.0.1"),
+        .package(url: "https://github.com/sindresorhus/KeyboardShortcuts", from: "2.4.0"),
         .package(url: "https://github.com/orchetect/MenuBarExtraAccess", exact: "1.3.0"),
     ],
     targets: [


### PR DESCRIPTION
## Summary

- update KeyboardShortcuts from 1.17.0 to 2.4.0
- retain the existing shortcut API, persisted shortcut names, and Swift 6.2 toolchain compatibility
- record the dependency update in the 0.10.2 changelog

## Dependency review

- Upstream 2.4.0: https://github.com/sindresorhus/KeyboardShortcuts/releases/tag/2.4.0
- Reviewed the 2.0.0 breaking changes. Trimmy uses neither the removed `on()` API nor incompatible shortcut APIs.
- 3.0.1 was evaluated first, then rejected after exact CI reproduced a Swift 6.2 compiler crash in `RecorderCocoa.isolated deinit`. Trimmy declares Swift tools 6.2; 2.4.0 is the newest compatible major line.
- No new transitive dependency or deployment-target increase for Trimmy.

## Proof

- `pnpm check`
- `swift test --parallel` — 175 tests passed
- `swift build -c release`
- `APP_IDENTITY='Apple Development: …' ./Scripts/package_app.sh debug` — packaged successfully
- `codesign --verify --deep --strict --verbose=2 Trimmy.app`
- local packaged-app validation: launched `com.steipete.trimmy.debug`; opened Settings → Shortcuts; verified all three recorders; entered and cancelled Paste Trimmed recording with Escape; confirmed `⌥⌘T` remained unchanged; app remained running
- Codex autoreview (`--mode local --parallel-tests 'pnpm check && swift test --parallel'`) — clean, no accepted/actionable findings

No release, version bump, tag, or publish is included.
