### PR TITLE
docs: rewrite README to house standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,143 +1,114 @@
-# Trimmy ✂️
+# Trimmy ✂️ — Paste once, run once.
 
-> **Paste once, run once.** A tiny macOS menu-bar app that flattens those multi-line shell snippets you copy from blogs, READMEs, and ChatGPT — so they actually paste and run.
-
+[![CI](https://img.shields.io/github/actions/workflow/status/steipete/Trimmy/ci.yml?branch=main&style=flat-square&label=ci)](https://github.com/steipete/Trimmy/actions/workflows/ci.yml)
+[![Latest release](https://img.shields.io/github/v/release/steipete/Trimmy?style=flat-square)](https://github.com/steipete/Trimmy/releases/latest)
 [![macOS 15+](https://img.shields.io/badge/macOS-15%2B-0d0c0a?style=flat-square)](https://www.apple.com/macos/)
-[![License: MIT](https://img.shields.io/badge/license-MIT-c4391f?style=flat-square)](LICENSE)
+[![License](https://img.shields.io/github/license/steipete/Trimmy?style=flat-square)](LICENSE)
 [![Homebrew](https://img.shields.io/badge/homebrew-steipete%2Ftap%2Ftrimmy-c4391f?style=flat-square)](https://github.com/steipete/homebrew-tap)
-[![Latest release](https://img.shields.io/github/v/release/steipete/Trimmy?style=flat-square&color=0d0c0a)](https://github.com/steipete/Trimmy/releases/latest)
+
+Trimmy is a macOS menu-bar app that turns copied multi-line shell snippets into one pasteable command. It watches the clipboard and uses command cues plus configurable sensitivity to avoid rewriting ordinary prose and code.
 
 ![Trimmy menu showing Paste Trimmed and Paste Original to Ghostty](trimmy.png)
 
+```sh
+printf '%s\n' \
+  'Trimmy' \
+  'is ready'
+# clipboard → printf '%s\n' 'Trimmy' 'is ready'
+```
+
+Trimmy rewrites the copy once; your next paste is a single command.
+
 ## Install
+
+On an Apple silicon Mac running macOS 15 or later:
 
 ```sh
 brew install --cask steipete/tap/trimmy
 ```
 
-…or grab the signed `.zip` from [Releases](https://github.com/steipete/Trimmy/releases/latest).
-Sparkle keeps it up-to-date automatically.
+You can instead download the signed app from [GitHub Releases](https://github.com/steipete/Trimmy/releases/latest). Sparkle checks for app updates after installation.
 
-## What it does
+## Quick start
 
-You copy this:
+1. Open Trimmy. The scissors icon appears in the menu bar.
+2. Copy the three-line `printf` command above.
+3. Paste into a terminal. Trimmy has changed the clipboard to one line, so the shell runs it once and prints:
 
-```sh
-kubectl get pods \
-    -n kube-system \
-    --selector='app=ingress' \
-    -o json | jq '.items[].metadata.name'
+```text
+Trimmy
+is ready
 ```
 
-Trimmy quietly rewrites your clipboard to this:
-
-```sh
-kubectl get pods -n kube-system --selector='app=ingress' -o json | jq '.items[].metadata.name'
-```
-
-You paste once, the shell runs once. No more `dquote>` prompts, no half-pasted commands, no “did you mean to run that as four separate commands?”
+The default sensitivity is Low in general apps and Normal in terminals. Use **Paste Original** from the menu whenever you need the untouched copy.
 
 ![Terminal example showing a wrapped command flattened into one line](term-example.png)
 
-## Highlights
+## Choose when Trimmy acts
 
-- **Lives in your menu bar.** No dock icon (`LSUIElement`). macOS 15 and later.
-- **Knows when it's a command.** Pipes, redirects, backslash continuations, `$` / `#` prompt gutters — all read as command cues. Markdown headings stay intact.
-- **Per-context aggressiveness.** Set the eagerness separately for general apps and terminals (Terminal, iTerm, Ghostty, Warp, kitty, WezTerm, Hyper, Alacritty).
-- **Two hotkeys.** Global *Paste Trimmed* and *Paste Original* — with a preview that shows the target app and strikes through what was removed.
-- **Reflows wrapped Markdown** as a separate menu action. Preserves fenced code, headings, and intentional blank lines.
-- **Strips URL query params** as a separate menu action. Keeps per-domain content identity (YouTube `v`/`list`/`t`, GitHub `tab`, Figma `node-id`, etc.); the keeplist is editable in Settings.
-- **Strips box-drawing gutters** (`│`, `┃`) so you can paste right out of fancy CLI tools.
-- **Stays on your Mac.** No telemetry, no auth, no network calls except Sparkle's update check. MIT licensed.
+Trimmy uses separate sensitivity settings for general apps and terminals. It recognizes Terminal, iTerm, Ghostty, Warp, kitty, WezTerm, Hyper, Alacritty, and cmux, and you can exclude specific apps or browser sites from automatic trimming.
+
+| Level | Behavior |
+| --- | --- |
+| **None** | Disables automatic trimming in general apps. |
+| **Low** | Requires strong cues such as pipes, redirects, or `\` continuations. |
+| **Normal** | Handles typical multi-line commands with flags. This is the terminal default. |
+| **High** | Flattens most command-shaped text. **Paste Trimmed** always uses this level. |
+
+Prompt gutters such as `$` and `#` are removed when they prefix a command, while Markdown headings remain intact. Automatic trimming skips large clipboard blobs as a safety valve.
+
+## Paste actions and permissions
+
+**Paste Trimmed** and **Paste Original** can be assigned global shortcuts. Their menu previews name the target app and show what trimming removed before sending a paste keystroke.
+
+These paste actions need macOS Accessibility permission. Trimmy prompts for it when necessary and links to **System Settings → Privacy & Security → Accessibility**. Automatic clipboard rewriting still works without simulated paste access.
+
+## Other cleanup actions
+
+The menu can reflow hard-wrapped Markdown while preserving headings, lists, blank lines, and fenced code. A separate action removes URL query parameters while retaining configured identity parameters such as YouTube video IDs, GitHub tabs, and Figma node IDs.
+
+Box-drawing gutters such as `│` and `┃` can also be removed from copied terminal output without stripping real shell pipes.
 
 ![Markdown reformatting example](markdown-trimmed.jpg)
 
-## Aggressiveness levels
-
-Settable per-context. **Low** is conservative; **High** flattens almost anything that looks command-shaped (and is what *Paste Trimmed* always uses). The defaults are tuned to be useful but never destructive: a 10-line safety valve skips auto-flatten on big blobs.
-
-| Level      | When it triggers                                              |
-| ---------- | ------------------------------------------------------------- |
-| **None**   | Off (general apps only).                                      |
-| **Low**    | Strong cues required: pipes, redirects, `\` continuations.    |
-| **Normal** | Typical multi-line commands with flags. Default in terminals. |
-| **High**   | Almost anything command-shaped. Used by *Paste Trimmed*.      |
-
-Prompt gutters get cleaned automatically, so `# brew install foo` becomes `brew install foo` while a Markdown heading like `# Release notes` is left alone.
-
-<details>
-<summary>Worked examples</summary>
-
-**Low** — `\` line continuations get joined:
-
-```sh
-ls -la \
-  | grep '^d' \
-  > dirs.txt
-# → ls -la | grep '^d' > dirs.txt
-```
-
-**Normal** — multi-line `kubectl` pipelines:
-
-```sh
-kubectl get pods \
-  -n kube-system \
-  | jq '.items[].metadata.name'
-# → kubectl get pods -n kube-system | jq '.items[].metadata.name'
-```
-
-**High** — even commands without explicit continuations:
-
-```sh
-echo "hello"
-print status
-# → echo "hello" print status
-```
-
-</details>
-
 ## Headless CLI
 
-There's a bundled CLI for scripts and pipelines:
+`TrimmyCLI` uses the same trimming engine without the menu-bar app. Run it from the source checkout:
 
 ```sh
-pbpaste | swift run TrimmyCLI --trim - --force
-swift run TrimmyCLI --trim ~/snippet.sh --aggressiveness high --json
+printf '%s\n' 'echo hello \' '  world' | swift run TrimmyCLI --trim --force
 ```
 
-Flags: `--aggressiveness {low|normal|high}`, `--force/-f` (forces High), `--preserve-blank-lines` / `--no-preserve-blank-lines`, `--remove-box-drawing` / `--keep-box-drawing`, `--json`.
-Exit codes: `0` ok · `1` no input/error · `2` no transformation · `3` JSON encode error.
+The result is `echo hello world`. The packaged app can install `trimmy` from **Settings → Advanced**, and Linux binaries are attached to [GitHub Releases](https://github.com/steipete/Trimmy/releases/latest).
 
-## Build from source
-
-Swift 6, macOS 15+:
-
-```sh
-swift build -c release
-./Scripts/package_app.sh release   # → Trimmy.app
-```
-
-Then run `Trimmy.app` (or add it to Login Items via the menu).
-
-```sh
-swiftformat .
-swiftlint lint --fix
-swift test
-```
+See the [CLI reference](docs/cli.md) for file input, JSON output, all options, and exit codes.
 
 ## How it works
 
-- ~150 ms polling timer with an 80 ms grace delay so promised pasteboard data lands before Trimmy decides what to do.
-- Clipboard writes carry a `com.steipete.trimmy` marker pasteboard type so Trimmy never reprocesses its own output.
-- Sparkle handles auto-updates: auto-check, auto-download, then the menu shows *“Update ready, restart now?”*
+- A roughly 150 ms timer watches for pasteboard ownership changes, followed by an 80 ms grace period for promised clipboard data.
+- Clipboard writes carry a `com.steipete.trimmy` marker so Trimmy does not process its own output.
+- Clipboard content stays local. Trimmy has no telemetry or account system; its network use is Sparkle's update check.
+
+The [technical specification](docs/spec.md) covers the detection heuristics, settings, and pasteboard behavior in more detail.
+
+## Development
+
+Trimmy requires Swift 6.2 and macOS 15 or later.
+
+```sh
+swift build
+swift test
+pnpm check
+./Scripts/package_app.sh debug
+```
 
 ## Related
 
-- ✂️ [Trimmy](https://trimmy.app) — this repo.
-- 🪶 [Alfred workflow](https://github.com/jimmystridh/alfred-trimmy) — community Alfred integration.
-- 🟦🟩 [CodexBar](https://codexbar.app) — keep Codex token windows visible in the menu bar.
-- 🧳 [MCPorter](https://mcporter.dev) — TypeScript toolkit + CLI for Model Context Protocol servers.
-- 🧿 [Oracle](https://github.com/steipete/oracle) — multi-model prompt bundler/CLI.
+- [trimmy.app](https://trimmy.app) is the project website.
+- [Alfred Trimmy](https://github.com/jimmystridh/alfred-trimmy) is a community Alfred workflow.
+- [CodexBar](https://codexbar.app) keeps Codex token windows visible in the menu bar.
+- [MCPorter](https://mcporter.dev) is a TypeScript toolkit and CLI for Model Context Protocol servers.
+- [Oracle](https://github.com/steipete/oracle) is a multi-model prompt bundler and CLI.
 
 ## License
 

--- a/Sources/Trimmy/ClipboardMonitor.swift
+++ b/Sources/Trimmy/ClipboardMonitor.swift
@@ -213,7 +213,9 @@ final class ClipboardMonitor: ObservableObject {
 
     func trimmedClipboardText(force: Bool = false) -> String? {
         guard let variants = self.makeVariants(force: force, ignoreMarker: force) else { return nil }
-        if !force, !variants.wasTransformed { return nil }
+        if !force, !variants.wasTransformed {
+            return nil
+        }
         return variants.trimmed
     }
 

--- a/Sources/Trimmy/MarkdownReformatter.swift
+++ b/Sources/Trimmy/MarkdownReformatter.swift
@@ -27,9 +27,15 @@ struct MarkdownReformatter {
 
     static func isLikelyMarkdown(_ text: String) -> Bool {
         let analysis = self.analyze(text)
-        if analysis.listCount >= 2 { return true }
-        if analysis.headingCount >= 2 { return true }
-        if analysis.headingCount >= 1, analysis.listCount >= 1 { return true }
+        if analysis.listCount >= 2 {
+            return true
+        }
+        if analysis.headingCount >= 2 {
+            return true
+        }
+        if analysis.headingCount >= 1, analysis.listCount >= 1 {
+            return true
+        }
         return false
     }
 

--- a/Sources/Trimmy/MenuContentView.swift
+++ b/Sources/Trimmy/MenuContentView.swift
@@ -325,10 +325,18 @@ extension KeyboardShortcuts.Key {
 extension EventModifiers {
     fileprivate init(_ flags: NSEvent.ModifierFlags) {
         var value: EventModifiers = []
-        if flags.contains(.command) { value.insert(.command) }
-        if flags.contains(.option) { value.insert(.option) }
-        if flags.contains(.control) { value.insert(.control) }
-        if flags.contains(.shift) { value.insert(.shift) }
+        if flags.contains(.command) {
+            value.insert(.command)
+        }
+        if flags.contains(.option) {
+            value.insert(.option)
+        }
+        if flags.contains(.control) {
+            value.insert(.control)
+        }
+        if flags.contains(.shift) {
+            value.insert(.shift)
+        }
         self = value
     }
 }

--- a/Sources/Trimmy/SettingsTrimmingPane.swift
+++ b/Sources/Trimmy/SettingsTrimmingPane.swift
@@ -139,14 +139,26 @@ enum AggressivenessPreviewEngine {
     static func score(for text: String) -> Int {
         guard text.contains("\n") else { return 0 }
         let lines = text.split(whereSeparator: { $0.isNewline })
-        if lines.count < 2 || lines.count > 10 { return 0 }
+        if lines.count < 2 || lines.count > 10 {
+            return 0
+        }
 
         var score = 0
-        if text.contains("\\\n") { score += 1 }
-        if text.range(of: #"[|&]{1,2}"#, options: .regularExpression) != nil { score += 1 }
-        if text.range(of: #"(^|\n)\s*\$"#, options: .regularExpression) != nil { score += 1 }
-        if text.range(of: #"(?m)^\s*(sudo\s+)?[A-Za-z0-9./~_-]+"#, options: .regularExpression) != nil { score += 1 }
-        if text.range(of: #"[-/]"#, options: .regularExpression) != nil { score += 1 }
+        if text.contains("\\\n") {
+            score += 1
+        }
+        if text.range(of: #"[|&]{1,2}"#, options: .regularExpression) != nil {
+            score += 1
+        }
+        if text.range(of: #"(^|\n)\s*\$"#, options: .regularExpression) != nil {
+            score += 1
+        }
+        if text.range(of: #"(?m)^\s*(sudo\s+)?[A-Za-z0-9./~_-]+"#, options: .regularExpression) != nil {
+            score += 1
+        }
+        if text.range(of: #"[-/]"#, options: .regularExpression) != nil {
+            score += 1
+        }
         return score
     }
 

--- a/Sources/TrimmyCore/TextCleaner.swift
+++ b/Sources/TrimmyCore/TextCleaner.swift
@@ -243,7 +243,9 @@ public struct TextCleaner: Sendable {
         if aggressivenessOverride != .high, self.isLikelyList(lines) {
             return nil
         }
-        if lines.count > 10 { return nil }
+        if lines.count > 10 {
+            return nil
+        }
 
         let nonEmptyLines = lines.filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
 
@@ -291,13 +293,27 @@ public struct TextCleaner: Sendable {
         }
 
         var score = 0
-        if text.contains("\\\n") { score += 1 }
-        if text.range(of: #"[|&]{1,2}"#, options: .regularExpression) != nil { score += 1 }
-        if text.range(of: #"(^|\n)\s*\$"#, options: .regularExpression) != nil { score += 1 }
-        if self.isSingleCommandWithIndentedContinuations(nonEmptyLines) { score += 1 }
-        if lines.allSatisfy(self.isLikelyCommandLine(_:)) { score += 1 }
-        if text.range(of: #"(?m)^\s*(sudo\s+)?[A-Za-z0-9./~_-]+"#, options: .regularExpression) != nil { score += 1 }
-        if text.range(of: #"[A-Za-z0-9._~-]+/[A-Za-z0-9._~-]+"#, options: .regularExpression) != nil { score += 1 }
+        if text.contains("\\\n") {
+            score += 1
+        }
+        if text.range(of: #"[|&]{1,2}"#, options: .regularExpression) != nil {
+            score += 1
+        }
+        if text.range(of: #"(^|\n)\s*\$"#, options: .regularExpression) != nil {
+            score += 1
+        }
+        if self.isSingleCommandWithIndentedContinuations(nonEmptyLines) {
+            score += 1
+        }
+        if lines.allSatisfy(self.isLikelyCommandLine(_:)) {
+            score += 1
+        }
+        if text.range(of: #"(?m)^\s*(sudo\s+)?[A-Za-z0-9./~_-]+"#, options: .regularExpression) != nil {
+            score += 1
+        }
+        if text.range(of: #"[A-Za-z0-9._~-]+/[A-Za-z0-9._~-]+"#, options: .regularExpression) != nil {
+            score += 1
+        }
 
         guard score >= aggressiveness.scoreThreshold else { return nil }
 
@@ -308,8 +324,12 @@ public struct TextCleaner: Sendable {
     private func isLikelyCommandLine(_ lineSubstr: Substring) -> Bool {
         let line = lineSubstr.trimmingCharacters(in: .whitespaces)
         guard !line.isEmpty else { return false }
-        if line.hasPrefix("[[") { return true }
-        if line.last == "." { return false }
+        if line.hasPrefix("[[") {
+            return true
+        }
+        if line.last == "." {
+            return false
+        }
         let pattern = #"^(sudo\s+)?[A-Za-z0-9./~_-]+(?:\s+|\z)"#
         return line.range(of: pattern, options: .regularExpression) != nil
     }
@@ -329,7 +349,9 @@ public struct TextCleaner: Sendable {
     private func isLikelyPromptCommand(_ content: Substring) -> Bool {
         let trimmed = String(content.trimmingCharacters(in: .whitespaces))
         guard !trimmed.isEmpty else { return false }
-        if let last = trimmed.last, [".", "?", "!"].contains(last) { return false }
+        if let last = trimmed.last, [".", "?", "!"].contains(last) {
+            return false
+        }
 
         let hasCommandPunctuation =
             trimmed.contains(where: { "-./~$".contains($0) }) || trimmed.contains(where: \.isNumber)
@@ -393,7 +415,9 @@ public struct TextCleaner: Sendable {
     }
 
     private func hasCommandPunctuation(_ text: String) -> Bool {
-        if text.contains("@") { return true }
+        if text.contains("@") {
+            return true
+        }
 
         if text.range(
             of: #"(?m)(?:^|\s)--[A-Za-z0-9][A-Za-z0-9_-]*"#,
@@ -430,7 +454,9 @@ public struct TextCleaner: Sendable {
             return true
         }
 
-        if text.contains("<") || text.contains(">") { return true }
+        if text.contains("<") || text.contains(">") {
+            return true
+        }
 
         return false
     }
@@ -455,7 +481,9 @@ public struct TextCleaner: Sendable {
     private func isLikelyStructuredData(_ lines: [Substring]) -> Bool {
         lines.contains { line in
             let trimmed = line.trimmingCharacters(in: .whitespaces)
-            if ["{", "}", "[", "]"].contains(trimmed) { return true }
+            if ["{", "}", "[", "]"].contains(trimmed) {
+                return true
+            }
             return trimmed.range(of: #"^["'][^"']+["']\s*:"#, options: .regularExpression) != nil
         }
     }
@@ -471,8 +499,12 @@ public struct TextCleaner: Sendable {
             let numberedPattern = #"^[0-9]+[.)]\s+\S"#
             let bareTokenPattern = #"^[A-Za-z0-9]{4,}$"#
 
-            if trimmed.range(of: bulletPattern, options: .regularExpression) != nil { return true }
-            if trimmed.range(of: numberedPattern, options: .regularExpression) != nil { return true }
+            if trimmed.range(of: bulletPattern, options: .regularExpression) != nil {
+                return true
+            }
+            if trimmed.range(of: numberedPattern, options: .regularExpression) != nil {
+                return true
+            }
             if !hasSpaces,
                trimmed.range(of: bareTokenPattern, options: .regularExpression) != nil,
                trimmed.range(of: #"[./$]"#, options: .regularExpression) == nil


### PR DESCRIPTION
## Summary

- Rewrites the README around the house-standard path: pitch, dynamic badges, install, 60-second proof, progressive controls, CLI, development, and license.
- Shrinks the front door from 144 to 115 lines while retaining all three screenshots, the community links, and author credit.
- Corrects distribution details to the live Apple-silicon Homebrew cask and signed GitHub release, with the Linux CLI release called out separately.

## Moved, condensed, or dropped

- No new docs were needed. Exhaustive CLI options and exit codes already live in `docs/cli.md`; heuristics and pasteboard internals already live in `docs/spec.md`.
- The feature wall and repetitive aggressiveness examples were condensed into the quick start, sensitivity table, and focused capability sections without dropping the represented behaviors.
- The old `--trim -` stdin example was dropped because the current parser treats `-` as a literal filename. The verified form is piped stdin with `--trim` and no filename. `docs/cli.md` still contains the pre-existing stale example and is outside this README-only lane.
- No changelog entry: the changelog has no docs-only entry precedent.

## Verification

- `swift build` — passed.
- `swift test` — 175 tests in 14 suites passed.
- README shell samples — syntax-checked with `zsh -n`; both original/transformed `printf` forms and the exact `TrimmyCLI` pipeline ran successfully (`echo hello world`).
- `brew install --cask steipete/tap/trimmy` — resolved the live cask; installed version 0.10.1 was already current.
- `./Scripts/package_app.sh debug` — passed; `codesign --verify --deep --strict` passed and both app/helper binaries are arm64.
- All six relative links resolve. Every external URL and badge returned HTTP 200; Shields SVGs contain no invalid/not-found card.
- Distribution/source cross-checks: Homebrew cask, GitHub release assets, `Package.swift`, workflow filename, settings defaults, terminal list, Accessibility gates, timers, and query rules.
- `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings.

Exact-head CI run [30775097065](https://github.com/steipete/Trimmy/actions/runs/30775097065) completed for `2b7918d4bb17b747593c439c03d3f21ac36029e2`: `build-linux-cli` and GitGuardian passed; `lint-build-test` failed in its SwiftFormat lint step. The same `pnpm check` failure reproduces locally on the untouched base, where SwiftFormat reports `wrapIfStatementBodies` in five existing Swift files; this README change does not touch them.

The interactive Accessibility/TCC clipboard flow was not UI-automated. The signed app packaged successfully, and the underlying behavior is covered by the passing test suite and CLI proof.
