### PR TITLE
chore(deps): update Sparkle and MenuBarExtraAccess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.10.2 — Unreleased
+- Dependencies: update Sparkle to 2.9.6 for installer security fixes and MenuBarExtraAccess to 1.3.1 for macOS 27 compatibility.
 - Terminal detection now recognizes cmux by bundle identifier and app name, so copies use terminal-specific trimming (thanks @gustavosmendes).
 - Dependencies: update KeyboardShortcuts to 2.4.0 for shortcut-recorder fixes while preserving Swift 6.2 compatibility.
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "74ae3a7dad7f4741a344505f2f9b029dc105f9dce7df8e9f4bb304406f96f7af",
+  "originHash" : "6da0d2a093f537ada39c5ad07015dd66608b45a7e22dd44e8830d2e43404330f",
   "pins" : [
     {
       "identity" : "keyboardshortcuts",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/orchetect/MenuBarExtraAccess",
       "state" : {
-        "revision" : "33bb0e4b1e407feac791e047dcaaf9c69b25fd26",
-        "version" : "1.3.0"
+        "revision" : "e93e3a5b814714bf4d4cea67bf63a6b6a8323968",
+        "version" : "1.3.1"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
-        "version" : "2.9.3"
+        "revision" : "ac2def288cbff5cfc7df3ffef6abdf45b72bcb0a",
+        "version" : "2.9.6"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -9,9 +9,9 @@ let package = Package(
         .macOS(.v15),
     ],
     dependencies: [
-        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.3"),
+        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.6"),
         .package(url: "https://github.com/sindresorhus/KeyboardShortcuts", from: "2.4.0"),
-        .package(url: "https://github.com/orchetect/MenuBarExtraAccess", exact: "1.3.0"),
+        .package(url: "https://github.com/orchetect/MenuBarExtraAccess", exact: "1.3.1"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Updates the two compatible SwiftPM dependencies while retaining Trimmy's Swift 6.2 support. The default branch was green before this change.

### Updates

- Sparkle 2.9.3 → 2.9.6, including upstream installer security fixes: https://github.com/sparkle-project/Sparkle/releases/tag/2.9.6
- MenuBarExtraAccess 1.3.0 → 1.3.1, including macOS 27 compatibility: https://github.com/orchetect/MenuBarExtraAccess/releases/tag/1.3.1
- Refresh Package.resolved and the 0.10.2 Unreleased changelog. No new dependencies or application-source changes.

### Held and already current

KeyboardShortcuts stays at 2.4.0. The current latest, 3.0.1, was already evaluated in #29: exact CI reproduced a Swift 6.2 compiler crash in RecorderCocoa's isolated deinitializer. This update retains that compatibility decision and does not raise the supported toolchain floor.

The GitHub Actions references are current: actions/checkout@v7 resolves to the same commit as v7.0.1, swift-actions/setup-swift is v2.4.0, and actions/upload-artifact is v7.0.1. package.json contains development commands but no npm dependencies. There are no open Dependabot or Renovate PRs superseded by this update.

### Validation

Local builds used stable Xcode 26.6 / Swift 6.3.3; the unchanged PR workflow separately checks Swift 6.2 on macOS and Swift 6.2.1 on Linux.

- SwiftPM dependency resolution and pnpm install passed.
- pnpm check passed: 0/47 files need formatting; SwiftLint reports 0 violations across 46 files. SwiftFormat, SwiftLint autocorrection, and strict lint also passed without source changes.
- swift build and swift build -c release passed.
- swift test --parallel passed: 175 tests in 14 suites, 0 failures.
- Built release CLI smoke passed 3/3 checks: help, text trimming, and JSON output.
- Scripts/package_app.sh debug passed with Developer ID signing. Deep, strict codesign verification passed.
- Signed packaged app stayed running for 3 seconds with auto-trim disabled; only the smoke-test process was stopped afterward. The global restart helper was deliberately not used because it kills unrelated running Trimmy instances.
- Codex autoreview passed with no actionable findings.

Baseline: [CI](https://github.com/steipete/Trimmy/actions/runs/30775797335) and [Pages](https://github.com/steipete/Trimmy/actions/runs/30775796685) were green. No baseline CI repair was needed. No release, tag, publishing, or merge is included.
