### PR TITLE
ci: validate macOS builds with Swift 6.2.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,12 @@ jobs:
           done
           /usr/bin/xcodebuild -version
 
-      - name: Install Swift 6.2 toolchain
+      - name: Install Swift 6.2.4 toolchain
         run: |
-          curl -L https://download.swift.org/swift-6.2-release/xcode/swift-6.2-RELEASE/swift-6.2-RELEASE-osx.pkg -o /tmp/swift.pkg
+          curl -fL https://download.swift.org/swift-6.2.4-release/xcode/swift-6.2.4-RELEASE/swift-6.2.4-RELEASE-osx.pkg -o /tmp/swift.pkg
           sudo installer -pkg /tmp/swift.pkg -target /
-          echo "/Library/Developer/Toolchains/swift-6.2-RELEASE.xctoolchain/usr/bin" >> "$GITHUB_PATH"
-          echo "TOOLCHAINS=swift-6.2-RELEASE" >> "$GITHUB_ENV"
+          echo "/Library/Developer/Toolchains/swift-6.2.4-RELEASE.xctoolchain/usr/bin" >> "$GITHUB_PATH"
+          echo "TOOLCHAINS=swift-6.2.4-RELEASE" >> "$GITHUB_ENV"
 
       - name: Install lint tools
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.10.2 — Unreleased
+- Build: validate macOS builds with Swift 6.2.4 while retaining Swift 6.2 and macOS 15 support.
 - Dependencies: update Sparkle to 2.9.6 for installer security fixes and MenuBarExtraAccess to 1.3.1 for macOS 27 compatibility.
 - Terminal detection now recognizes cmux by bundle identifier and app name, so copies use terminal-specific trimming (thanks @gustavosmendes).
 - Dependencies: update KeyboardShortcuts to 2.4.0 for shortcut-recorder fixes while preserving Swift 6.2 compatibility.


### PR DESCRIPTION
macOS CI currently validates with the initial Swift 6.2 release. Update its official installer and toolchain selection to Swift 6.2.4, and make HTTP download errors fail immediately. Trimmy's Swift 6.2 source requirement and macOS 15 deployment minimum stay unchanged.

Linux CI and Linux release builds remain on Swift 6.2.1: the current `swift-actions/setup-swift@v2.4.0` bundles a version allowlist that does not accept 6.2.4. This PR leaves that installer migration for separate work.

Validation:
- `pnpm check` — zero formatting or lint violations.
- `Scripts/compile_and_run.sh` with two compiler jobs and the native build engine — 175 tests in 14 suites passed; Developer ID signed app built and launched.
- Strict/deep codesign verification passed. Real macOS clipboard checks flattened a synthetic multiline command and preserved prose; bundled CLI checks verified JSON output and unchanged-input exit code 2.
- `swift build --build-system native --jobs 2 -c release` and optimized CLI smoke check passed. Release Mach-O metadata retains macOS 15.0 minimum for app and CLI.
- Full P0–P2 Codex autoreview — no accepted/actionable findings after removing the unsupported Linux version bump.

Local validation used Xcode's Swift 6.4 beta with its supported native build engine. Its new default engine failed to locate Sparkle when loading app tests; the native-engine run above completed all tests. Exact Swift 6.2.4 coverage is supplied by this PR's macOS CI job.
