### PR TITLE
docs: prepare 0.10.2 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,10 @@
 
 **Highlights:** Safer automatic updates and clipboard handling.
 
-- Update Sparkle to 2.9.6 for installer security fixes.
+- Dependencies: update Sparkle to 2.9.6 for installer security fixes and MenuBarExtraAccess to 1.3.1 for macOS 27 compatibility.
 - Terminal detection now recognizes cmux by bundle identifier and app name, so copies use terminal-specific trimming (thanks @gustavosmendes).
 - Preserve YAML block-scalar indentation during automatic trimming in the app and CLI (thanks @rewtraw).
-- Update KeyboardShortcuts to 2.4.0 for shortcut-recorder fixes while preserving Swift 6.2 compatibility.
-- Update MenuBarExtraAccess to 1.3.1 for macOS 27 compatibility.
+- Dependencies: update KeyboardShortcuts to 2.4.0 for shortcut-recorder fixes while preserving Swift 6.2 compatibility.
 - Build: validate macOS builds with Swift 6.2.4 while retaining Swift 6.2 and macOS 15 support.
 
 ## 0.10.1 — 2026-06-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## 0.10.2 — Unreleased
 
-**Highlights:** Safer automatic updates and terminal-aware trimming for cmux.
+**Highlights:** Safer automatic updates and clipboard handling.
 
 - Update Sparkle to 2.9.6 for installer security fixes.
 - Terminal detection now recognizes cmux by bundle identifier and app name, so copies use terminal-specific trimming (thanks @gustavosmendes).
+- Preserve YAML block-scalar indentation during automatic trimming in the app and CLI (thanks @rewtraw).
 - Update KeyboardShortcuts to 2.4.0 for shortcut-recorder fixes while preserving Swift 6.2 compatibility.
 - Update MenuBarExtraAccess to 1.3.1 for macOS 27 compatibility.
 - Build: validate macOS builds with Swift 6.2.4 while retaining Swift 6.2 and macOS 15 support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
 ## 0.10.2 — Unreleased
-- Build: validate macOS builds with Swift 6.2.4 while retaining Swift 6.2 and macOS 15 support.
-- Dependencies: update Sparkle to 2.9.6 for installer security fixes and MenuBarExtraAccess to 1.3.1 for macOS 27 compatibility.
+
+**Highlights:** Safer automatic updates and terminal-aware trimming for cmux.
+
+- Update Sparkle to 2.9.6 for installer security fixes.
 - Terminal detection now recognizes cmux by bundle identifier and app name, so copies use terminal-specific trimming (thanks @gustavosmendes).
-- Dependencies: update KeyboardShortcuts to 2.4.0 for shortcut-recorder fixes while preserving Swift 6.2 compatibility.
+- Update KeyboardShortcuts to 2.4.0 for shortcut-recorder fixes while preserving Swift 6.2 compatibility.
+- Update MenuBarExtraAccess to 1.3.1 for macOS 27 compatibility.
+- Build: validate macOS builds with Swift 6.2.4 while retaining Swift 6.2 and macOS 15 support.
 
 ## 0.10.1 — 2026-06-11
 - Settings: reorganize controls into focused General, Trimming, Rules, Shortcuts, Advanced, and About tabs, with low-frequency cleanup options under Advanced and a compact native macOS layout.


### PR DESCRIPTION
Prepare the 0.10.2 patch release notes around Sparkle installer security fixes, cmux recognition, YAML preservation, and shortcut/menu-bar compatibility. Add a Highlights lead-in and order the five bullets for users while preserving published changelog sections and version metadata.

Land #35 first for the YAML fix described here. Automatic prose reflow in #31 remains a separate feature decision. The two prepared branches were checked for a clean combined merge.

Validation: release-note and appcast-HTML generation retain the Highlights paragraph and all five bullets; published sections are byte-for-byte unchanged; independent local and branch review are clean. Exact-head CI and native app proof are recorded in the proof comment.
