### PR TITLE
fix: preserve YAML block scalars during automatic trimming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Build: validate macOS builds with Swift 6.2.4 while retaining Swift 6.2 and macOS 15 support.
 - Dependencies: update Sparkle to 2.9.6 for installer security fixes and MenuBarExtraAccess to 1.3.1 for macOS 27 compatibility.
 - Terminal detection now recognizes cmux by bundle identifier and app name, so copies use terminal-specific trimming (thanks @gustavosmendes).
+- Preserve YAML block-scalar indentation during automatic trimming in the app and CLI (thanks @rewtraw).
 - Dependencies: update KeyboardShortcuts to 2.4.0 for shortcut-recorder fixes while preserving Swift 6.2 compatibility.
 
 ## 0.10.1 — 2026-06-11

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Trimmy uses separate sensitivity settings for general apps and terminals. It rec
 
 Prompt gutters such as `$` and `#` are removed when they prefix a command, while Markdown headings remain intact. Automatic trimming skips large clipboard blobs as a safety valve.
 
+Low and Normal sensitivity preserve YAML block scalars and their required indentation. High sensitivity and manual **Paste Trimmed** still flatten on request.
+
 ## Paste actions and permissions
 
 **Paste Trimmed** and **Paste Original** can be assigned global shortcuts. Their menu previews name the target app and show what trimming removed before sending a paste keystroke.

--- a/Sources/Trimmy/ClipboardMonitor.swift
+++ b/Sources/Trimmy/ClipboardMonitor.swift
@@ -506,6 +506,16 @@ extension ClipboardMonitor {
     }
 
     private func transform(text: String, force: Bool, sourceContext: ClipboardSourceContext?) -> ClipboardVariants {
+        let isTerminal = sourceContext?.isTerminal == true
+        let useTerminalAggressiveness = isTerminal && self.settings.contextAwareTrimmingEnabled
+        let baseAggressiveness = useTerminalAggressiveness
+            ? self.settings.terminalAggressiveness
+            : self.settings.generalAggressiveness.coreAggressiveness
+        let overrideAggressiveness: Aggressiveness? = force ? .high : nil
+        let commandAggressiveness = overrideAggressiveness ?? baseAggressiveness
+        if commandAggressiveness != .high, TextCleaner.containsYAMLBlockScalar(text) {
+            return ClipboardVariants(original: text, trimmed: text, wasTransformed: false)
+        }
         var currentText = text
         var wasTransformed = false
 
@@ -542,14 +552,6 @@ extension ClipboardMonitor {
             currentText = quotedPath
             wasTransformed = true
         }
-
-        let isTerminal = sourceContext?.isTerminal == true
-        let useTerminalAggressiveness = isTerminal && self.settings.contextAwareTrimmingEnabled
-        let baseAggressiveness = useTerminalAggressiveness
-            ? self.settings.terminalAggressiveness
-            : self.settings.generalAggressiveness.coreAggressiveness
-        let overrideAggressiveness: Aggressiveness? = force ? .high : nil
-        let commandAggressiveness = overrideAggressiveness ?? baseAggressiveness
 
         if useTerminalAggressiveness, let sourceContext {
             Telemetry.clipboard.debug(

--- a/Sources/TrimmyCore/TextCleaner.swift
+++ b/Sources/TrimmyCore/TextCleaner.swift
@@ -143,7 +143,7 @@ public struct TextCleaner: Sendable {
         guard !self.isLikelyList(nonEmptyLines),
               !self.isLikelySourceCode(text),
               !self.isLikelyStructuredData(nonEmptyLines),
-              !self.containsYAMLBlockScalar(nonEmptyLines),
+              !Self.containsYAMLBlockScalar(text),
               !self.hasCommandPunctuation(text)
         else {
             return nil
@@ -177,11 +177,25 @@ public struct TextCleaner: Sendable {
 
     // MARK: - Public pipeline
 
+    public static func containsYAMLBlockScalar(_ text: String) -> Bool {
+        // Preserve raw scalar contents before cleanup can strip meaningful indentation or glyphs.
+        let prefix = #"(?:---\s+)?(?:(?:[^#\s][^\r\n]*)?:\s*)?(?:-\s+)*"#
+        let properties = #"(?:(?:!\S*|&\S+)\s+)*"#
+        let scalar = #"[|>](?:[1-9][+-]?|[+-][1-9]?)?(?:\s+#.*)?$"#
+        return text.split(whereSeparator: \.isNewline).contains { line in
+            line.trimmingCharacters(in: .whitespaces)
+                .range(of: "^" + prefix + properties + scalar, options: .regularExpression) != nil
+        }
+    }
+
     public func transform(
         _ text: String,
         config: TrimConfig,
         aggressivenessOverride: Aggressiveness? = nil) -> TrimResult
     {
+        if (aggressivenessOverride ?? config.aggressiveness) != .high, Self.containsYAMLBlockScalar(text) {
+            return TrimResult(original: text, trimmed: text, wasTransformed: false)
+        }
         var currentText = text
         var wasTransformed = false
 
@@ -250,7 +264,7 @@ public struct TextCleaner: Sendable {
 
         let nonEmptyLines = lines.filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
         let aggressiveness = aggressivenessOverride ?? config.aggressiveness
-        if aggressiveness != .high, self.containsYAMLBlockScalar(nonEmptyLines) {
+        if aggressiveness != .high, Self.containsYAMLBlockScalar(text) {
             return nil
         }
 
@@ -479,16 +493,6 @@ public struct TextCleaner: Sendable {
             return false
         }
         return line.contains(where: \.isWhitespace) || line.range(of: #"[,.!?;:]"#, options: .regularExpression) != nil
-    }
-
-    private func containsYAMLBlockScalar(_ lines: [Substring]) -> Bool {
-        // A YAML literal marker is not a shell pipe, and its content indentation is significant.
-        let prefix = #"(?:(?:[^#\s][^\r\n]*)?:\s*|-\s+)?"#
-        let scalar = #"[|>](?:[1-9][+-]?|[+-][1-9]?)?(?:\s+#.*)?$"#
-        return lines.contains { line in
-            line.trimmingCharacters(in: .whitespaces)
-                .range(of: "^" + prefix + scalar, options: .regularExpression) != nil
-        }
     }
 
     private func isLikelyStructuredData(_ lines: [Substring]) -> Bool {

--- a/Sources/TrimmyCore/TextCleaner.swift
+++ b/Sources/TrimmyCore/TextCleaner.swift
@@ -143,6 +143,7 @@ public struct TextCleaner: Sendable {
         guard !self.isLikelyList(nonEmptyLines),
               !self.isLikelySourceCode(text),
               !self.isLikelyStructuredData(nonEmptyLines),
+              !self.containsYAMLBlockScalar(nonEmptyLines),
               !self.hasCommandPunctuation(text)
         else {
             return nil
@@ -248,6 +249,10 @@ public struct TextCleaner: Sendable {
         }
 
         let nonEmptyLines = lines.filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+        let aggressiveness = aggressivenessOverride ?? config.aggressiveness
+        if aggressiveness != .high, self.containsYAMLBlockScalar(nonEmptyLines) {
+            return nil
+        }
 
         let hasLineContinuation = text.contains("\\\n")
         let hasLineJoinerAtEOL = text.range(
@@ -266,8 +271,6 @@ public struct TextCleaner: Sendable {
         {
             return nil
         }
-
-        let aggressiveness = aggressivenessOverride ?? config.aggressiveness
 
         let strongCommandSignals = text.contains("\\\n")
             || text.range(of: #"[|&]{1,2}"#, options: .regularExpression) != nil
@@ -476,6 +479,16 @@ public struct TextCleaner: Sendable {
             return false
         }
         return line.contains(where: \.isWhitespace) || line.range(of: #"[,.!?;:]"#, options: .regularExpression) != nil
+    }
+
+    private func containsYAMLBlockScalar(_ lines: [Substring]) -> Bool {
+        // A YAML literal marker is not a shell pipe, and its content indentation is significant.
+        let prefix = #"(?:(?:[^#\s][^\r\n]*)?:\s*|-\s+)?"#
+        let scalar = #"[|>](?:[1-9][+-]?|[+-][1-9]?)?(?:\s+#.*)?$"#
+        return lines.contains { line in
+            line.trimmingCharacters(in: .whitespaces)
+                .range(of: "^" + prefix + scalar, options: .regularExpression) != nil
+        }
     }
 
     private func isLikelyStructuredData(_ lines: [Substring]) -> Bool {

--- a/Tests/TrimmyCLITests/TrimmyCLITests.swift
+++ b/Tests/TrimmyCLITests/TrimmyCLITests.swift
@@ -86,6 +86,16 @@ struct TrimmyCLITests {
     }
 
     @Test
+    func `preserves YAML literal blocks`() {
+        let input = "description: |\n  This paragraph belongs to a YAML scalar.\n  Its indentation is required."
+        for aggressiveness in [Aggressiveness.low, .normal] {
+            let result = cliTrim(input, settings: CLISettings(aggressiveness: aggressiveness), force: false)
+            #expect(!result.transformed)
+            #expect(result.trimmed == input)
+        }
+    }
+
+    @Test
     func `pyenv init stays multiline when safer`() {
         let input = """
         export PYENV_ROOT="$HOME/.pyenv"

--- a/Tests/TrimmyCLITests/TrimmyCLITests.swift
+++ b/Tests/TrimmyCLITests/TrimmyCLITests.swift
@@ -85,9 +85,13 @@ struct TrimmyCLITests {
         #expect(result.trimmed == input)
     }
 
-    @Test
-    func `preserves YAML literal blocks`() {
-        let input = "description: |\n  This paragraph belongs to a YAML scalar.\n  Its indentation is required."
+    @Test(arguments: [
+        "description: |\n  This paragraph belongs to a YAML scalar.\n  Its indentation is required.",
+        "art: |\n  │ hello\n  │ world",
+        "script: &anchor |\n  $ echo one\n  $ echo two",
+        "description: !!str |\n  This paragraph belongs to a YAML scalar.\n  Its indentation is required.",
+    ])
+    func `preserves YAML literal blocks`(input: String) {
         for aggressiveness in [Aggressiveness.low, .normal] {
             let result = cliTrim(input, settings: CLISettings(aggressiveness: aggressiveness), force: false)
             #expect(!result.transformed)

--- a/Tests/TrimmyTests/ClipboardMonitorTests.swift
+++ b/Tests/TrimmyTests/ClipboardMonitorTests.swift
@@ -43,6 +43,33 @@ struct ClipboardMonitorTests {
     }
 
     @Test
+    func `automatic trimming preserves YAML literal indentation`() {
+        let settings = AppSettings()
+        let originalAutoTrim = settings.autoTrimEnabled
+        let originalContextAware = settings.contextAwareTrimmingEnabled
+        let originalAggressiveness = settings.generalAggressiveness
+        defer {
+            settings.autoTrimEnabled = originalAutoTrim
+            settings.contextAwareTrimmingEnabled = originalContextAware
+            settings.generalAggressiveness = originalAggressiveness
+        }
+        settings.autoTrimEnabled = true
+        settings.contextAwareTrimmingEnabled = false
+        let input = "description: |\n  This paragraph belongs to a YAML scalar.\n  Its indentation is required."
+        for aggressiveness in [GeneralAggressiveness.none, .low, .normal] {
+            settings.generalAggressiveness = aggressiveness
+            let pasteboard = makeTestPasteboard()
+            let monitor = ClipboardMonitor(
+                settings: settings,
+                pasteboard: pasteboard,
+                accessibilityPermission: StubAccessibilityPermission())
+            pasteboard.setString(input, forType: .string)
+            #expect(!monitor.trimClipboardIfNeeded(force: false))
+            #expect(pasteboard.string(forType: .string) == input)
+        }
+    }
+
+    @Test
     func `manual trim reads own marker`() {
         let settings = AppSettings()
         settings.autoTrimEnabled = false

--- a/Tests/TrimmyTests/ClipboardMonitorTests.swift
+++ b/Tests/TrimmyTests/ClipboardMonitorTests.swift
@@ -42,8 +42,13 @@ struct ClipboardMonitorTests {
         #expect(monitor.clipboardText() != nil)
     }
 
-    @Test
-    func `automatic trimming preserves YAML literal indentation`() {
+    @Test(arguments: [
+        "description: |\n  This paragraph belongs to a YAML scalar.\n  Its indentation is required.",
+        "art: |\n  │ hello\n  │ world",
+        "script: &anchor |\n  $ echo one\n  $ echo two",
+        "description: !!str |\n  This paragraph belongs to a YAML scalar.\n  Its indentation is required.",
+    ])
+    func `automatic trimming preserves YAML literal indentation`(input: String) {
         let settings = AppSettings()
         let originalAutoTrim = settings.autoTrimEnabled
         let originalContextAware = settings.contextAwareTrimmingEnabled
@@ -55,7 +60,6 @@ struct ClipboardMonitorTests {
         }
         settings.autoTrimEnabled = true
         settings.contextAwareTrimmingEnabled = false
-        let input = "description: |\n  This paragraph belongs to a YAML scalar.\n  Its indentation is required."
         for aggressiveness in [GeneralAggressiveness.none, .low, .normal] {
             settings.generalAggressiveness = aggressiveness
             let pasteboard = makeTestPasteboard()

--- a/Tests/TrimmyTests/ParagraphDedentTests.swift
+++ b/Tests/TrimmyTests/ParagraphDedentTests.swift
@@ -102,6 +102,10 @@ struct ParagraphDedentTests {
         "description: |2- # literal", "description: |-2", "description: >-",
         "- description: |", "- |", "\"description\": |", "'description': |",
         "release notes: |", "123: |", "説明: |", "https://example.com: |", "|", ": |",
+        "description: !custom |", "description: !!str |", "script: &anchor |",
+        "description: &anchor !!str |", "description: !!str &anchor |", "- !custom |",
+        "!<tag:yaml.org,2002:str> |",
+        "description: ! |", "--- |", "- - |",
     ])
     func `preserves YAML block scalar indentation`(header: String) {
         let input = "\(header)\n  This paragraph belongs to a YAML scalar.\n  Its indentation is required."

--- a/Tests/TrimmyTests/ParagraphDedentTests.swift
+++ b/Tests/TrimmyTests/ParagraphDedentTests.swift
@@ -97,6 +97,38 @@ struct ParagraphDedentTests {
         #expect(result.trimmed == "echo hello && echo world")
     }
 
+    @Test(arguments: [
+        "description: |", "description: |-", "description: |+",
+        "description: |2- # literal", "description: |-2", "description: >-",
+        "- description: |", "- |", "\"description\": |", "'description': |",
+        "release notes: |", "123: |", "説明: |", "https://example.com: |", "|", ": |",
+    ])
+    func `preserves YAML block scalar indentation`(header: String) {
+        let input = "\(header)\n  This paragraph belongs to a YAML scalar.\n  Its indentation is required."
+        #expect(self.cleaner.dedentParagraphIndent(input) == nil)
+        for aggressiveness in [Aggressiveness.low, .normal] {
+            let result = self.cleaner.transform(
+                input,
+                config: TrimConfig(
+                    aggressiveness: aggressiveness,
+                    preserveBlankLines: false,
+                    removeBoxDrawing: true))
+            #expect(!result.wasTransformed)
+            #expect(result.trimmed == input)
+        }
+    }
+
+    @Test
+    func `manual high override still flattens YAML on request`() {
+        let input = "description: |\n  This paragraph belongs to a YAML scalar.\n  Its indentation is required."
+        let result = self.cleaner.transform(
+            input,
+            config: TrimConfig(aggressiveness: .low, preserveBlankLines: false, removeBoxDrawing: true),
+            aggressivenessOverride: .high)
+        #expect(result.wasTransformed)
+        #expect(!result.trimmed.contains("\n"))
+    }
+
     @Test
     func `clipboard detector exposes paragraph dedent`() {
         let settings = AppSettings()


### PR DESCRIPTION
Copying a YAML block scalar such as `description: |` can remove required indentation, and Normal sensitivity can mistake the literal marker for a shell pipe. Earlier cleanup can also strip literal box-drawing or prompt characters from scalar contents, producing invalid or altered YAML.

Recognize block-scalar headers in the shared engine and preserve the raw input before cleanup in both the app and CLI. Coverage includes plain/quoted/numeric/Unicode keys, tags, anchors, scalar modifiers, document markers, and sequence items. High sensitivity and manual forced trimming retain their existing behavior.

Regression tests exercise the shared engine, CLI, and app clipboard monitor using UUID-named test pasteboards. Documentation and the Unreleased changelog are updated; thanks @rewtraw for surfacing the preservation case in #31. Automatic text reflow in #31 remains a separate feature decision.

Validation: formatting/lint and 179 tests in 14 suites pass. Local and branch autoreviews are clean. Exact-head CI and signed-app Peekaboo proof are recorded in the proof comment. Native UI validation disables auto-trim and global hotkeys; system-clipboard mutation is excluded.
