### PR TITLE
docs: prepare 0.11.0 reflow release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 0.10.3 — Unreleased
+## 0.11.0 — Unreleased
+
+**Highlights:** Optional automatic reflow for copied prose and Markdown.
+
+- Join hard-wrapped prose and Markdown automatically with a new default-off setting, respecting app/site exclusions and preserving fenced examples before command cleanup (thanks @rewtraw).
+- Expand the manual action to Paste Reflowed Text, with shared checks that leave recognized source code and configuration out of both reflow paths (thanks @rewtraw).
+- Add optional removal of leading blank lines during reflow, disabled by default to preserve existing paste behavior (thanks @rewtraw).
 
 ## 0.10.2 — 2026-09-05
 


### PR DESCRIPTION
Prepare the next minor release around optional automatic reflow for copied prose and Markdown. The Unreleased section credits @rewtraw, explains the default-off behavior, and preserves every published changelog section.

Land #31 first. This branch contains the complete release notes separately so the feature PR has no changelog conflict. Version metadata and release artifacts remain at 0.10.2 until release authorization.

The dependency audit found no new compatible updates: Sparkle 2.9.6, MenuBarExtraAccess 1.3.1, checkout v7/v7.0.1, setup-swift 2.4.0, and upload-artifact 7.0.1 are current. KeyboardShortcuts 3.0.1 remains held because #29 reproduced its compiler crash on the supported Swift 6.2 toolchain; 2.4.0 stays pinned.

Validation: Markdown and Sparkle HTML note generation preserve Highlights and all three bullets. Published sections are unchanged. Independent local and branch P0–P2 autoreview passes are clean. Native baseline validation passed all 179 tests, built and launched the Developer ID signed app, and opened Settings with Peekaboo. Exact-head CI will be recorded in a proof comment.
