### PR TITLE
chore(deps): update KeyboardShortcuts to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.11.1 — Unreleased
 
+**Highlights:** More reliable keyboard shortcuts and shortcut recording.
+
+- Update KeyboardShortcuts to 3.1.0 for shortcut-recorder fixes, responsive menu highlighting, function-key shortcuts while menus are open, and improved macOS 27 compatibility.
+
 ## 0.11.0 — 2026-09-07
 
 **Highlights:** Optional automatic reflow for copied prose and Markdown.

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "6da0d2a093f537ada39c5ad07015dd66608b45a7e22dd44e8830d2e43404330f",
+  "originHash" : "6d4357f8b872b527b6112b2e9bcf4db0e2cacbf9c2123002e7f07ed02837b441",
   "pins" : [
     {
       "identity" : "keyboardshortcuts",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sindresorhus/KeyboardShortcuts",
       "state" : {
-        "revision" : "1aef85578fdd4f9eaeeb8d53b7b4fc31bf08fe27",
-        "version" : "2.4.0"
+        "revision" : "772133d9dbe800fdac0473226822994c5c162c58",
+        "version" : "3.1.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.6"),
-        .package(url: "https://github.com/sindresorhus/KeyboardShortcuts", from: "2.4.0"),
+        .package(url: "https://github.com/sindresorhus/KeyboardShortcuts", from: "3.1.0"),
         .package(url: "https://github.com/orchetect/MenuBarExtraAccess", exact: "1.3.1"),
     ],
     targets: [


### PR DESCRIPTION
## Verdict: close; retain KeyboardShortcuts 2.4.0

This upgrade is incompatible with Trimmy's supported Swift 6.2.4 toolchain despite KeyboardShortcuts 3.1.0 declaring a Swift 6.2 package manifest. Do not merge the dependency or candidate release notes.

[CI run 34664525908](https://github.com/steipete/Trimmy/actions/runs/34664525908) tested commit `9975f05a7a527e01a15df53c484338f1f9dacc04`. The macOS compiler aborts while emitting KeyboardShortcuts, serializing the isolated `RecorderCocoa` destructor at line 221:

```text
Assertion failed: (Attr->canAppearOnDecl(D) && "attribute cannot appear on a " "Destructor")
Apple Swift version 6.2.4 (swift-6.2.4-RELEASE)
While running pass SILModuleTransform "SerializeSILPass".
```

The Linux CLI job passes because it does not compile the macOS shortcut dependency. The default branch remains unchanged and green.

## Validation completed

- All 200 tests and `pnpm check` pass locally with Swift 6.4 and native SwiftPM.
- The Developer ID signed debug app builds and launches. Settings opens; shortcut recorders retain the default shortcuts and accept both a new function-key shortcut and re-recording that same shortcut.
- The signed app joins a multiline shell command when Auto-Trim is enabled and preserves it when disabled. The bundled CLI produces the expected single-line output.
- Both local and committed-branch autoreview are clean through P2.

## Limits and recommendation

The local Xcode beta's new default build system could not load Sparkle into the test runner, so local validation used the native build system already selected by Trimmy's packaging script. This does not address the separate Swift 6.2.4 compiler crash above.

Synthetic global-hotkey delivery was inconclusive on this host and also failed against the preserved older signed app. Recorder input, settings controls, and clipboard processing were verified directly.

Keep 2.4.0 until upstream supplies a release that passes the existing Swift 6.2.4 CI. Raising Trimmy's minimum toolchain solely for this dependency needs a separate compatibility decision. No release is warranted from this candidate.
